### PR TITLE
Implement RGB KVStore Integration

### DIFF
--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -51,6 +51,7 @@ libm = { version = "0.2", default-features = false }
 inventory = { version = "0.3", optional = true  }
 
 # RGB and related
+bincode = "1.3"
 futures = "0.3"
 rgb-lib = { version = "0.3.0-beta.5", features = [
     "electrum",
@@ -59,7 +60,6 @@ rgb-lib = { version = "0.3.0-beta.5", features = [
 serde = { version = "^1.0", features = [
     "derive",
 ] }
-serde_json = "^1.0"
 tokio = { version = "1.14.1", features = [
     "macros",
     "rt-multi-thread",

--- a/lightning/src/ln/chan_utils.rs
+++ b/lightning/src/ln/chan_utils.rs
@@ -36,6 +36,7 @@ use crate::ln::msgs::DecodeError;
 use crate::rgb_utils::{color_htlc, is_tx_colored};
 use crate::sign::EntropySource;
 use crate::types::payment::{PaymentHash, PaymentPreimage};
+use crate::util::persist::KVStoreSync;
 use crate::util::ser::{Readable, ReadableArgs, RequiredWrapper, Writeable, Writer};
 use crate::util::transaction_utils;
 
@@ -2156,6 +2157,7 @@ impl<'a> TrustedCommitmentTransaction<'a> {
 	pub fn get_htlc_sigs<T: secp256k1::Signing, ES: Deref>(
 		&self, htlc_base_key: &SecretKey, channel_parameters: &DirectedChannelTransactionParameters,
 		entropy_source: &ES, secp_ctx: &Secp256k1<T>, ldk_data_dir: &PathBuf,
+		rgb_kv_store: &dyn KVStoreSync,
 	) -> Result<Vec<Signature>, ()> where ES::Target: EntropySource {
 		let inner = self.inner;
 		let keys = &inner.keys;
@@ -2167,7 +2169,7 @@ impl<'a> TrustedCommitmentTransaction<'a> {
 			assert!(this_htlc.transaction_output_index.is_some());
 			let mut htlc_tx = build_htlc_transaction(&txid, inner.feerate_per_kw, channel_parameters.contest_delay(), &this_htlc, &self.channel_type_features, &keys.broadcaster_delayed_payment_key, &keys.revocation_key);
 			if inner.is_colored() {
-				if let Err(_e) = color_htlc(&mut htlc_tx, this_htlc, ldk_data_dir) {
+				if let Err(_e) = color_htlc(&mut htlc_tx, this_htlc, ldk_data_dir, rgb_kv_store) {
 					return Err(());
 				}
 			}

--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -78,9 +78,8 @@ use crate::ln::types::ChannelId;
 use crate::ln::LN_MAX_MSG_LEN;
 use crate::offers::static_invoice::StaticInvoice;
 use crate::rgb_utils::{
-	color_closing, color_commitment, color_htlc, get_rgb_channel_info_path,
-	get_rgb_channel_info_pending, parse_rgb_channel_info, rename_rgb_files,
-	update_rgb_channel_amount_pending,
+	color_closing, color_commitment, color_htlc, get_rgb_channel_info_pending, rename_rgb_files,
+	update_rgb_channel_amount_pending, RgbKvStoreExt,
 };
 use crate::routing::gossip::NodeId;
 use crate::sign::ecdsa::EcdsaChannelSigner;
@@ -104,6 +103,8 @@ use crate::prelude::*;
 use crate::sign::type_resolver::ChannelSignerType;
 #[cfg(any(test, fuzzing, debug_assertions))]
 use crate::sync::Mutex;
+use crate::sync::Arc;
+use crate::util::persist::KVStoreSync;
 use core::ops::Deref;
 use core::time::Duration;
 use core::{cmp, fmt, mem};
@@ -3174,6 +3175,9 @@ where
 	pub(super) is_colored: bool,
 
 	pub(crate) ldk_data_dir: PathBuf,
+
+	/// KVStore for RGB data persistence
+	pub(crate) rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 }
 
 /// A channel struct implementing this trait can receive an initial counterparty commitment
@@ -3273,8 +3277,8 @@ where
 		let context = self.context_mut();
 		let temporary_channel_id = context.channel_id;
 		context.channel_id = channel_id;
-		if context.is_colored() {
-			rename_rgb_files(&context.channel_id, &temporary_channel_id, &context.ldk_data_dir);
+		if context.is_colored() && temporary_channel_id != channel_id {
+			rename_rgb_files(&context.channel_id, &temporary_channel_id, context.rgb_kv_store.as_ref());
 		}
 
 		assert!(!context.channel_state.is_monitor_update_in_progress()); // We have not had any monitor(s) yet to fail update!
@@ -3444,6 +3448,7 @@ where
 		open_channel_fields: msgs::CommonOpenChannelFields,
 		push_asset_amount: Option<u64>,
 		ldk_data_dir: PathBuf,
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Result<(FundingScope, ChannelContext<SP>), ChannelError>
 		where
 			ES::Target: EntropySource,
@@ -3769,6 +3774,7 @@ where
 
 			is_colored: funding.consignment_endpoint.is_some(),
 			ldk_data_dir,
+			rgb_kv_store,
 		};
 
 		Ok((funding, channel_context))
@@ -3795,6 +3801,7 @@ where
 		consignment_endpoint: Option<RgbTransport>,
 		ldk_data_dir: PathBuf,
 		push_asset_amount: Option<u64>,
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Result<(FundingScope, ChannelContext<SP>), APIError>
 		where
 			ES::Target: EntropySource,
@@ -4016,6 +4023,7 @@ where
 
 			is_colored: funding.consignment_endpoint.is_some(),
 			ldk_data_dir,
+			rgb_kv_store,
 		};
 
 		Ok((funding, channel_context))
@@ -4396,13 +4404,8 @@ where
 
 	/// Get the channel local RGB amount
 	pub fn get_local_rgb_amount(&self) -> u64 {
-		let info_file_path = get_rgb_channel_info_path(
-			&self.channel_id.0.as_hex().to_string(),
-			&self.ldk_data_dir,
-			false,
-		);
-		if info_file_path.exists() {
-			let rgb_info = parse_rgb_channel_info(&info_file_path);
+		let channel_id_str = self.channel_id.0.as_hex().to_string();
+		if let Ok(rgb_info) = self.rgb_kv_store.read_rgb_channel_info(&channel_id_str, false) {
 			rgb_info.local_rgb_amount
 		} else {
 			0
@@ -4411,13 +4414,8 @@ where
 
 	/// Get the channel remote RGB amount
 	pub fn get_remote_rgb_amount(&self) -> u64 {
-		let info_file_path = get_rgb_channel_info_path(
-			&self.channel_id.0.as_hex().to_string(),
-			&self.ldk_data_dir,
-			false,
-		);
-		if info_file_path.exists() {
-			let rgb_info = parse_rgb_channel_info(&info_file_path);
+		let channel_id_str = self.channel_id.0.as_hex().to_string();
+		if let Ok(rgb_info) = self.rgb_kv_store.read_rgb_channel_info(&channel_id_str, false) {
 			rgb_info.remote_rgb_amount
 		} else {
 			0
@@ -5142,7 +5140,7 @@ where
 				&holder_keys.revocation_key,
 			);
 			if self.is_colored() && !self.is_trusted_no_broadcast() {
-				color_htlc(&mut htlc_tx, htlc, &self.ldk_data_dir)
+				color_htlc(&mut htlc_tx, htlc, &self.ldk_data_dir, self.rgb_kv_store.as_ref())
 					.expect("successful htlc coloring");
 			}
 
@@ -7395,6 +7393,7 @@ where
 				&self.context.channel_id,
 				&mut closing_transaction,
 				&self.context.ldk_data_dir,
+				self.context.rgb_kv_store.as_ref(),
 			)
 			.expect("successful closing TX coloring");
 		}
@@ -8994,7 +8993,7 @@ where
 				&self.context.channel_id,
 				rgb_offered_htlc,
 				rgb_received_htlc,
-				&self.context.ldk_data_dir,
+				self.context.rgb_kv_store.as_ref(),
 			);
 		}
 
@@ -11809,7 +11808,7 @@ where
 		let were_node_one = node_id.as_slice() < counterparty_node_id.as_slice();
 
 		let contract_id = if self.context.is_colored() {
-			let (rgb_info, _) = get_rgb_channel_info_pending(&self.context.channel_id, &self.context.ldk_data_dir);
+			let rgb_info = get_rgb_channel_info_pending(&self.context.channel_id, self.context.rgb_kv_store.as_ref());
 			Some(rgb_info.contract_id)
 		} else {
 			None
@@ -12963,7 +12962,7 @@ where
 			}
 		}
 		if self.context.is_colored() && rgb_received_htlc > 0 {
-			update_rgb_channel_amount_pending(&self.context.channel_id, 0, rgb_received_htlc, &self.context.ldk_data_dir);
+			update_rgb_channel_amount_pending(&self.context.channel_id, 0, rgb_received_htlc, self.context.rgb_kv_store.as_ref());
 		}
 		if let Some((feerate, update_state)) = self.context.pending_update_fee {
 			if update_state == FeeUpdateState::AwaitingRemoteRevokeToAnnounce {
@@ -13630,6 +13629,7 @@ where
 		fee_estimator: &LowerBoundedFeeEstimator<F>, entropy_source: &ES, signer_provider: &SP, counterparty_node_id: PublicKey, their_features: &InitFeatures,
 		channel_value_satoshis: u64, push_msat: u64, user_id: u128, config: &UserConfig, current_chain_height: u32,
 		outbound_scid_alias: u64, temporary_channel_id: Option<ChannelId>, logger: L, consignment_endpoint: Option<RgbTransport>, ldk_data_dir: PathBuf, push_asset_amount: Option<u64>,
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Result<OutboundV1Channel<SP>, APIError>
 	where ES::Target: EntropySource,
 	      F::Target: FeeEstimator,
@@ -13672,6 +13672,7 @@ where
 			consignment_endpoint,
 			ldk_data_dir,
 			push_asset_amount,
+			rgb_kv_store,
 		)?;
 		let unfunded_context = UnfundedChannelContext {
 			unfunded_channel_age_ticks: 0,
@@ -13755,7 +13756,7 @@ where
 		let temporary_channel_id = self.context.channel_id;
 		self.context.channel_id = ChannelId::v1_from_funding_outpoint(funding_txo);
 		if self.context.is_colored() {
-			rename_rgb_files(&self.context.channel_id, &temporary_channel_id, &self.context.ldk_data_dir);
+			rename_rgb_files(&self.context.channel_id, &temporary_channel_id, self.context.rgb_kv_store.as_ref());
 		}
 
 		// If the funding transaction is a coinbase transaction, we need to set the minimum depth to 100.
@@ -14009,7 +14010,8 @@ where
 		fee_estimator: &LowerBoundedFeeEstimator<F>, entropy_source: &ES, signer_provider: &SP,
 		counterparty_node_id: PublicKey, our_supported_features: &ChannelTypeFeatures,
 		their_features: &InitFeatures, msg: &msgs::OpenChannel, user_id: u128, config: &UserConfig,
-		current_chain_height: u32, logger: &L, is_0conf: bool, ldk_data_dir: PathBuf
+		current_chain_height: u32, logger: &L, is_0conf: bool, ldk_data_dir: PathBuf,
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Result<InboundV1Channel<SP>, ChannelError>
 		where ES::Target: EntropySource,
 			  F::Target: FeeEstimator,
@@ -14051,6 +14053,7 @@ where
 			msg.common_fields.clone(),
 			msg.push_asset_amount,
 			ldk_data_dir,
+			rgb_kv_store,
 		)?;
 		let unfunded_context = UnfundedChannelContext {
 			unfunded_channel_age_ticks: 0,
@@ -14251,7 +14254,7 @@ where
 		counterparty_node_id: PublicKey, their_features: &InitFeatures, funding_satoshis: u64,
 		funding_inputs: Vec<FundingTxInput>, user_id: u128, config: &UserConfig,
 		current_chain_height: u32, outbound_scid_alias: u64, funding_confirmation_target: ConfirmationTarget,
-		logger: L, ldk_data_dir: PathBuf,
+		logger: L, ldk_data_dir: PathBuf, rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Result<Self, APIError>
 	where ES::Target: EntropySource,
 	      F::Target: FeeEstimator,
@@ -14295,6 +14298,7 @@ where
 			None,
 			ldk_data_dir,
 			None,
+			rgb_kv_store,
 		)?;
 		let unfunded_context = UnfundedChannelContext {
 			unfunded_channel_age_ticks: 0,
@@ -14405,7 +14409,7 @@ where
 		holder_node_id: PublicKey, counterparty_node_id: PublicKey, our_supported_features: &ChannelTypeFeatures,
 		their_features: &InitFeatures, msg: &msgs::OpenChannelV2,
 		user_id: u128, config: &UserConfig, current_chain_height: u32, logger: &L,
-		ldk_data_dir: PathBuf,
+		ldk_data_dir: PathBuf, rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Result<Self, ChannelError>
 		where ES::Target: EntropySource,
 			  F::Target: FeeEstimator,
@@ -14452,6 +14456,7 @@ where
 			msg.common_fields.clone(),
 			None,
 			ldk_data_dir,
+			rgb_kv_store,
 		)?;
 		let channel_id = ChannelId::v2_from_revocation_basepoints(
 			&funding.get_holder_pubkeys().revocation_basepoint,
@@ -15144,16 +15149,16 @@ where
 	}
 }
 
-impl<'a, 'b, 'c, ES: Deref, SP: Deref>
-	ReadableArgs<(&'a ES, &'b SP, &'c ChannelTypeFeatures, PathBuf)> for FundedChannel<SP>
+impl<'a, 'b, 'c, ES: Deref, SP: Deref> ReadableArgs<(&'a ES, &'b SP, &'c ChannelTypeFeatures, PathBuf, Arc<dyn KVStoreSync + Send + Sync>)>
+	for FundedChannel<SP>
 where
 	ES::Target: EntropySource,
 	SP::Target: SignerProvider,
 {
 	fn read<R: io::Read>(
-		reader: &mut R, args: (&'a ES, &'b SP, &'c ChannelTypeFeatures, PathBuf),
+		reader: &mut R, args: (&'a ES, &'b SP, &'c ChannelTypeFeatures, PathBuf, Arc<dyn KVStoreSync + Send + Sync>),
 	) -> Result<Self, DecodeError> {
-		let (entropy_source, signer_provider, our_supported_features, ldk_data_dir) = args;
+		let (entropy_source, signer_provider, our_supported_features, ldk_data_dir, rgb_kv_store) = args;
 		let ver = read_ver_prefix!(reader, SERIALIZATION_VERSION);
 		if ver <= 2 {
 			return Err(DecodeError::UnknownVersion);
@@ -15955,6 +15960,7 @@ where
 				interactive_tx_signing_session,
 				is_colored: consignment_endpoint.is_some(),
 				ldk_data_dir,
+				rgb_kv_store,
 			},
 			holder_commitment_point,
 			pending_splice,

--- a/lightning/src/ln/channelmanager.rs
+++ b/lightning/src/ln/channelmanager.rs
@@ -119,10 +119,7 @@ use crate::onion_message::messenger::{
 	MessageRouter, MessageSendInstructions, Responder, ResponseInstruction,
 };
 use crate::onion_message::offers::{OffersMessage, OffersMessageHandler};
-use crate::rgb_utils::{
-	get_rgb_channel_info, get_rgb_payment_info_path, handle_funding, is_channel_rgb,
-	parse_rgb_payment_info,
-};
+use crate::rgb_utils::{handle_funding, is_channel_rgb, RgbKvStoreExt};
 use crate::routing::router::{
 	BlindedTail, FixedRouter, InFlightHtlcs, Path, Payee, PaymentParameters, Route,
 	RouteParameters, RouteParametersConfig, Router,
@@ -139,6 +136,7 @@ use crate::types::string::UntrustedString;
 use crate::util::config::{ChannelConfig, ChannelConfigOverrides, ChannelConfigUpdate, UserConfig};
 use crate::util::errors::APIError;
 use crate::util::logger::{Level, Logger, WithContext};
+use crate::util::persist::KVStoreSync;
 use crate::util::scid_utils::fake_scid;
 use crate::util::ser::{
 	BigSize, FixedLengthReader, LengthReadable, MaybeReadable, Readable, ReadableArgs, VecWriter,
@@ -2973,6 +2971,9 @@ pub struct ChannelManager<
 	logger: L,
 
 	ldk_data_dir: PathBuf,
+
+	/// KVStore for RGB data persistence
+	rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 }
 
 /// Chain-related parameters used to construct a new `ChannelManager`.
@@ -3996,7 +3997,8 @@ where
 	pub fn new(
 		fee_est: F, chain_monitor: M, tx_broadcaster: T, router: R, message_router: MR, logger: L,
 		entropy_source: ES, node_signer: NS, signer_provider: SP, config: UserConfig,
-		params: ChainParameters, current_timestamp: u32, ldk_data_dir: PathBuf
+		params: ChainParameters, current_timestamp: u32, ldk_data_dir: PathBuf,
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Self
 	where
 		L: Clone,
@@ -4025,7 +4027,7 @@ where
 			best_block: RwLock::new(params.best_block),
 
 			outbound_scid_aliases: Mutex::new(new_hash_set()),
-			pending_outbound_payments: OutboundPayments::new(new_hash_map(), ldk_data_dir.clone()),
+			pending_outbound_payments: OutboundPayments::new(new_hash_map(), rgb_kv_store.clone()),
 			forward_htlcs: Mutex::new(new_hash_map()),
 			decode_update_add_htlcs: Mutex::new(new_hash_map()),
 			claimable_payments: Mutex::new(ClaimablePayments { claimable_payments: new_hash_map(), pending_claiming_payments: new_hash_map() }),
@@ -4072,6 +4074,7 @@ where
 			testing_dnssec_proof_offer_resolution_override: Mutex::new(new_hash_map()),
 
 			ldk_data_dir,
+			rgb_kv_store,
 		}
 	}
 
@@ -4190,7 +4193,8 @@ where
 			};
 			match OutboundV1Channel::new(&self.fee_estimator, &self.entropy_source, &self.signer_provider, their_network_key,
 				their_features, channel_value_satoshis, push_msat, user_channel_id, config,
-				self.best_block.read().unwrap().height, outbound_scid_alias, temporary_channel_id, &*self.logger, consignment_endpoint, self.ldk_data_dir.clone(), push_asset_amount)
+				self.best_block.read().unwrap().height, outbound_scid_alias, temporary_channel_id, &*self.logger, consignment_endpoint, self.ldk_data_dir.clone(), push_asset_amount,
+				self.rgb_kv_store.clone())
 			{
 				Ok(res) => res,
 				Err(e) => {
@@ -5383,18 +5387,11 @@ where
 		// The top-level caller should hold the total_consistency_lock read lock.
 		debug_assert!(self.total_consistency_lock.try_write().is_err());
 
-		let rgb_payment_info_hash_path_outbound =
-			get_rgb_payment_info_path(payment_hash, &self.ldk_data_dir, false);
-		let needs_rgb_modification = if rgb_payment_info_hash_path_outbound.exists() {
-			let info = parse_rgb_payment_info(&rgb_payment_info_hash_path_outbound);
-			if !info.swap_payment {
-				Some(info)
-			} else {
-				None
-			}
-		} else {
-			None
-		};
+		let needs_rgb_modification =
+			match self.rgb_kv_store.read_rgb_payment_info(payment_hash, false) {
+				Ok(info) if !info.swap_payment => Some(info),
+				_ => None,
+			};
 		let modified_path;
 		let path = if let Some(rgb_payment_info) = needs_rgb_modification {
 			modified_path = {
@@ -7720,15 +7717,14 @@ where
 								.contains(&outgoing_amt_msat);
 							if is_in_range && chan.context.is_usable() {
 								if let Some((cid, outgoing_amount_rgb)) = outgoing_rgb_payment {
-									if !is_channel_rgb(&chan.context.channel_id, &self.ldk_data_dir)
+									if !is_channel_rgb(&chan.context.channel_id, self.rgb_kv_store.as_ref())
 									{
 										return None;
 									}
-									let (rgb_chan_info, _) = get_rgb_channel_info(
+									let rgb_chan_info = self.rgb_kv_store.read_rgb_channel_info(
 										&chan.context.channel_id.0.as_hex().to_string(),
-										&self.ldk_data_dir,
 										false,
-									);
+									).expect("channel info must exist in KVStore");
 									if rgb_chan_info.contract_id == *cid
 										&& rgb_chan_info.local_rgb_amount >= *outgoing_amount_rgb
 									{
@@ -10217,7 +10213,8 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 						InboundV1Channel::new(
 							&self.fee_estimator, &self.entropy_source, &self.signer_provider, *counterparty_node_id,
 							&self.channel_type_features(), &peer_state.latest_features, &open_channel_msg,
-							user_channel_id, &config, best_block_height, &self.logger, accept_0conf, self.ldk_data_dir.clone()
+							user_channel_id, &config, best_block_height, &self.logger, accept_0conf, self.ldk_data_dir.clone(),
+							self.rgb_kv_store.clone(),
 						).map_err(|err| MsgHandleErrInternal::from_chan_no_close(err, *temporary_channel_id)
 						).map(|mut channel| {
 							Self::apply_inbound_channel_funding_type(&mut channel.context, channel_funding_type);
@@ -10240,6 +10237,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 							user_channel_id, &config, best_block_height,
 							&self.logger,
 							self.ldk_data_dir.clone(),
+							self.rgb_kv_store.clone(),
 						).map_err(|e| {
 							let channel_id = open_channel_msg.common_fields.temporary_channel_id;
 							MsgHandleErrInternal::from_chan_no_close(e, channel_id)
@@ -10510,7 +10508,8 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 				let mut channel = InboundV1Channel::new(
 					&self.fee_estimator, &self.entropy_source, &self.signer_provider, *counterparty_node_id,
 					&self.channel_type_features(), &peer_state.latest_features, msg, user_channel_id,
-					&self.config.read().unwrap(), best_block_height, &self.logger, /*is_0conf=*/false, self.ldk_data_dir.clone()
+					&self.config.read().unwrap(), best_block_height, &self.logger, /*is_0conf=*/false, self.ldk_data_dir.clone(),
+					self.rgb_kv_store.clone(),
 				).map_err(|e| MsgHandleErrInternal::from_chan_no_close(e, msg.common_fields.temporary_channel_id))?;
 				let logger = WithChannelContext::from(&self.logger, &channel.context, None);
 				let message_send_event = channel.accept_inbound_channel(&&logger).map(|msg| {
@@ -10528,6 +10527,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 					&peer_state.latest_features, msg, user_channel_id,
 					&self.config.read().unwrap(), best_block_height, &self.logger,
 					self.ldk_data_dir.clone(),
+					self.rgb_kv_store.clone(),
 				).map_err(|e| MsgHandleErrInternal::from_chan_no_close(e, msg.common_fields.temporary_channel_id))?;
 				let message_send_event = MessageSendEvent::SendAcceptChannelV2 {
 					node_id: *counterparty_node_id,
@@ -10612,7 +10612,7 @@ This indicates a bug inside LDK. Please report this error at https://github.com/
 				Some(Ok(inbound_chan)) => {
 					let logger = WithChannelContext::from(&self.logger, &inbound_chan.context, None);
 					if let Some(consignment_endpoint) = &inbound_chan.funding.consignment_endpoint {
-						handle_funding(&msg.temporary_channel_id, msg.funding_txid.to_string(), &self.ldk_data_dir, consignment_endpoint.clone(), inbound_chan.funding.push_asset_amount)?;
+						handle_funding(&msg.temporary_channel_id, msg.funding_txid.to_string(), &self.ldk_data_dir, consignment_endpoint.clone(), inbound_chan.funding.push_asset_amount, self.rgb_kv_store.as_ref())?;
 					}
 					match inbound_chan.funding_created(msg, best_block, &self.signer_provider, &&logger) {
 						Ok(res) => res,
@@ -16973,6 +16973,9 @@ pub struct ChannelManagerReadArgs<
 
 	/// LDK data directory
 	pub ldk_data_dir: PathBuf,
+
+	/// KVStore for RGB data persistence
+	pub rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 }
 
 impl<
@@ -17007,6 +17010,7 @@ where
 		config: UserConfig,
 		mut channel_monitors: Vec<&'a ChannelMonitor<<SP::Target as SignerProvider>::EcdsaSigner>>,
 		ldk_data_dir: PathBuf,
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Self {
 		Self {
 			entropy_source,
@@ -17023,6 +17027,7 @@ where
 				channel_monitors.drain(..).map(|monitor| (monitor.channel_id(), monitor)),
 			),
 			ldk_data_dir,
+			rgb_kv_store,
 		}
 	}
 }
@@ -17126,6 +17131,7 @@ where
 					&args.signer_provider,
 					&provided_channel_type_features(&args.config),
 					args.ldk_data_dir.clone(),
+					args.rgb_kv_store.clone(),
 				),
 			)?;
 			let logger = WithChannelContext::from(&args.logger, &channel.context, None);
@@ -17555,7 +17561,7 @@ where
 			}
 			pending_outbound_payments = Some(outbounds);
 		}
-		let pending_outbounds = OutboundPayments::new(pending_outbound_payments.unwrap(), args.ldk_data_dir.clone());
+		let pending_outbounds = OutboundPayments::new(pending_outbound_payments.unwrap(), args.rgb_kv_store.clone());
 
 		for (peer_pubkey, peer_storage) in peer_storage_dir {
 			if let Some(peer_state) = per_peer_state.get_mut(&peer_pubkey) {
@@ -18498,6 +18504,7 @@ where
 			testing_dnssec_proof_offer_resolution_override: Mutex::new(new_hash_map()),
 
 			ldk_data_dir: args.ldk_data_dir,
+			rgb_kv_store: args.rgb_kv_store,
 		};
 
 		let mut processed_claims: HashSet<Vec<MPPClaimHTLCSource>> = new_hash_set();

--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -26,9 +26,7 @@ use crate::offers::invoice::{Bolt12Invoice, DerivedSigningPubkey, InvoiceBuilder
 use crate::offers::invoice_request::InvoiceRequest;
 use crate::offers::nonce::Nonce;
 use crate::offers::static_invoice::StaticInvoice;
-use crate::rgb_utils::{
-	filter_first_hops, get_rgb_payment_info_path, is_payment_rgb, parse_rgb_payment_info,
-};
+use crate::rgb_utils::RgbKvStoreExt;
 use crate::routing::router::{
 	BlindedTail, InFlightHtlcs, Path, PaymentParameters, Route, RouteParameters,
 	RouteParametersConfig, Router,
@@ -47,10 +45,9 @@ use core::ops::Deref;
 use core::sync::atomic::{AtomicBool, Ordering};
 use core::time::Duration;
 
-use std::path::PathBuf;
-
 use crate::prelude::*;
-use crate::sync::Mutex;
+use crate::sync::{Arc, Mutex};
+use crate::util::persist::KVStoreSync;
 
 /// The number of ticks of [`ChannelManager::timer_tick_occurred`] until we time-out the idempotency
 /// of payments by [`PaymentId`]. See [`OutboundPayments::remove_stale_payments`].
@@ -846,13 +843,13 @@ pub(super) struct OutboundPayments {
 	pub(super) pending_outbound_payments: Mutex<HashMap<PaymentId, PendingOutboundPayment>>,
 	awaiting_invoice: AtomicBool,
 	retry_lock: Mutex<()>,
-	ldk_data_dir: PathBuf,
+	rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 }
 
 impl OutboundPayments {
 	pub(super) fn new(
 		pending_outbound_payments: HashMap<PaymentId, PendingOutboundPayment>,
-		ldk_data_dir: PathBuf,
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Self {
 		let has_invoice_requests = pending_outbound_payments.values().any(|payment| {
 			matches!(
@@ -867,7 +864,7 @@ impl OutboundPayments {
 			pending_outbound_payments: Mutex::new(pending_outbound_payments),
 			awaiting_invoice: AtomicBool::new(has_invoice_requests),
 			retry_lock: Mutex::new(()),
-			ldk_data_dir,
+			rgb_kv_store,
 		}
 	}
 }
@@ -1050,9 +1047,14 @@ impl OutboundPayments {
 		}
 
 		let mut filtered_first_hops = first_hops.into_iter().collect::<Vec<_>>();
-		let rgb_payment = is_payment_rgb(&self.ldk_data_dir, &payment_hash).then(|| {
-			filter_first_hops(&self.ldk_data_dir, &payment_hash, &mut filtered_first_hops)
-		});
+		let rgb_payment = if self.rgb_kv_store.is_payment_rgb(&payment_hash) {
+			self.rgb_kv_store.filter_first_hops(&payment_hash, &mut filtered_first_hops);
+			let info = self.rgb_kv_store.read_rgb_payment_info(&payment_hash, false)
+				.expect("payment info must exist");
+			Some((info.contract_id, info.amount))
+		} else {
+			None
+		};
 		let mut route_params = RouteParameters::from_payment_params_and_value(
 			PaymentParameters::from_bolt12_invoice(&invoice)
 				.with_user_config_ignoring_fee_limit(params_config), invoice.amount_msats(),
@@ -1411,14 +1413,11 @@ impl OutboundPayments {
 						..
 					} = pmt
 					{
-						let rgb_payment_info_path =
-							get_rgb_payment_info_path(payment_hash, &self.ldk_data_dir, false);
-						let rgb_payment = if rgb_payment_info_path.exists() {
-							let rgb_payment_info = parse_rgb_payment_info(&rgb_payment_info_path);
-							Some((rgb_payment_info.contract_id, rgb_payment_info.amount))
-						} else {
-							None
-						};
+						let rgb_payment =
+							match self.rgb_kv_store.read_rgb_payment_info(payment_hash, false) {
+								Ok(info) => Some((info.contract_id, info.amount)),
+								Err(_) => None,
+							};
 						if pending_amt_msat < total_msat {
 							retry_id_route_params = Some((
 								*payment_hash,
@@ -1570,9 +1569,9 @@ impl OutboundPayments {
 		SP: Fn(SendAlongPathArgs) -> Result<(), APIError>,
 	{
 		let mut filtered_first_hops = first_hops.into_iter().collect::<Vec<_>>();
-		is_payment_rgb(&self.ldk_data_dir, &payment_hash).then(|| {
-			filter_first_hops(&self.ldk_data_dir, &payment_hash, &mut filtered_first_hops)
-		});
+		if self.rgb_kv_store.is_payment_rgb(&payment_hash) {
+			self.rgb_kv_store.filter_first_hops(&payment_hash, &mut filtered_first_hops);
+		}
 		let route = self.find_initial_route(
 			payment_id, payment_hash, &recipient_onion, keysend_preimage, None, &mut route_params, router,
 			&filtered_first_hops, &inflight_htlcs, node_signer, best_block_height, logger,
@@ -1627,9 +1626,9 @@ impl OutboundPayments {
 		}
 
 		let mut filtered_first_hops = first_hops.into_iter().collect::<Vec<_>>();
-		is_payment_rgb(&self.ldk_data_dir, &payment_hash).then(|| {
-			filter_first_hops(&self.ldk_data_dir, &payment_hash, &mut filtered_first_hops)
-		});
+		if self.rgb_kv_store.is_payment_rgb(&payment_hash) {
+			self.rgb_kv_store.filter_first_hops(&payment_hash, &mut filtered_first_hops);
+		}
 
 		let mut route = match router.find_route_with_id(
 			&node_signer.get_node_id(Recipient::Node).unwrap(), &route_params,

--- a/lightning/src/rgb_utils/mod.rs
+++ b/lightning/src/rgb_utils/mod.rs
@@ -11,6 +11,7 @@ use crate::ln::types::ChannelId;
 use crate::sign::SignerProvider;
 use crate::types::features::ChannelTypeFeatures;
 use crate::types::payment::PaymentHash;
+use crate::util::persist::KVStoreSync;
 
 use bitcoin::blockdata::transaction::Transaction;
 use bitcoin::hex::DisplayHex;
@@ -29,13 +30,14 @@ use rgb_lib::{
 use serde::{Deserialize, Serialize};
 use tokio::runtime::Handle;
 
+use crate::io;
 use core::ops::Deref;
 use std::collections::HashMap;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::str::FromStr;
+use std::sync::Arc;
 
-/// Static blinding costant (will be removed in the future)
+/// Static blinding constant (will be removed in the future)
 pub const STATIC_BLINDING: u64 = 777;
 /// Name of the file containing the bitcoin network
 pub const BITCOIN_NETWORK_FNAME: &str = "bitcoin_network";
@@ -49,9 +51,24 @@ pub const WALLET_ACCOUNT_XPUB_VANILLA_FNAME: &str = "wallet_account_xpub_vanilla
 pub const WALLET_ACCOUNT_XPUB_COLORED_FNAME: &str = "wallet_account_xpub_colored";
 /// Name of the file containing the master fingerprint of the wallet
 pub const WALLET_MASTER_FINGERPRINT_FNAME: &str = "wallet_master_fingerprint";
-const INBOUND_EXT: &str = "inbound";
-const OUTBOUND_EXT: &str = "outbound";
-const VIRTUAL_CHANNEL_MARKER_PREFIX: &str = "virtual_channel_";
+
+// kv_store namespace constants for RGB data persistence
+/// Primary namespace for all RGB data
+pub const RGB_PRIMARY_NS: &str = "rgb";
+/// Secondary namespace for channel info
+pub const RGB_CHANNEL_INFO_NS: &str = "channel_info";
+/// Secondary namespace for pending channel info
+pub const RGB_CHANNEL_INFO_PENDING_NS: &str = "channel_info_pending";
+/// Secondary namespace for inbound payment info
+pub const RGB_PAYMENT_INFO_INBOUND_NS: &str = "payment_info_inbound";
+/// Secondary namespace for outbound payment info
+pub const RGB_PAYMENT_INFO_OUTBOUND_NS: &str = "payment_info_outbound";
+/// Secondary namespace for transfer info
+pub const RGB_TRANSFER_INFO_NS: &str = "transfer_info";
+/// Secondary namespace for consignment data
+pub const RGB_CONSIGNMENT_NS: &str = "consignment";
+/// Secondary namespace for wallet configuration
+pub const RGB_WALLET_CONFIG_NS: &str = "wallet_config";
 
 /// RGB channel info
 #[derive(Debug, Clone, Deserialize, Serialize)]
@@ -116,38 +133,32 @@ mod contract_id_serde {
 	}
 }
 
-fn _get_file_in_parent(ldk_data_dir: &Path, fname: &str) -> PathBuf {
-	ldk_data_dir.parent().unwrap().join(fname)
-}
-
-fn _read_file_in_parent(ldk_data_dir: &Path, fname: &str) -> String {
-	fs::read_to_string(_get_file_in_parent(ldk_data_dir, fname)).unwrap()
-}
-
-fn _get_rgb_wallet_dir(ldk_data_dir: &Path) -> PathBuf {
-	let fingerprint = _read_file_in_parent(ldk_data_dir, WALLET_FINGERPRINT_FNAME);
-	_get_file_in_parent(ldk_data_dir, &fingerprint)
-}
-
-fn _get_bitcoin_network(ldk_data_dir: &Path) -> BitcoinNetwork {
-	let bitcoin_network = _read_file_in_parent(ldk_data_dir, BITCOIN_NETWORK_FNAME);
+fn _get_bitcoin_network(kv_store: &dyn KVStoreSync) -> BitcoinNetwork {
+	let bitcoin_network =
+		kv_store.read_config(BITCOIN_NETWORK_FNAME).expect("bitcoin_network must be in KVStore");
 	BitcoinNetwork::from_str(&bitcoin_network).unwrap()
 }
 
-fn _get_account_xpub_colored(ldk_data_dir: &Path) -> String {
-	_read_file_in_parent(ldk_data_dir, WALLET_ACCOUNT_XPUB_COLORED_FNAME)
+fn _get_account_xpub_colored(kv_store: &dyn KVStoreSync) -> String {
+	kv_store
+		.read_config(WALLET_ACCOUNT_XPUB_COLORED_FNAME)
+		.expect("account_xpub_colored must be in KVStore")
 }
 
-fn _get_account_xpub_vanilla(ldk_data_dir: &Path) -> String {
-	_read_file_in_parent(ldk_data_dir, WALLET_ACCOUNT_XPUB_VANILLA_FNAME)
+fn _get_account_xpub_vanilla(kv_store: &dyn KVStoreSync) -> String {
+	kv_store
+		.read_config(WALLET_ACCOUNT_XPUB_VANILLA_FNAME)
+		.expect("account_xpub_vanilla must be in KVStore")
 }
 
-fn _get_master_fingerprint(ldk_data_dir: &Path) -> String {
-	_read_file_in_parent(ldk_data_dir, WALLET_MASTER_FINGERPRINT_FNAME)
+fn _get_master_fingerprint(kv_store: &dyn KVStoreSync) -> String {
+	kv_store
+		.read_config(WALLET_MASTER_FINGERPRINT_FNAME)
+		.expect("master_fingerprint must be in KVStore")
 }
 
-fn _get_indexer_url(ldk_data_dir: &Path) -> String {
-	_read_file_in_parent(ldk_data_dir, INDEXER_URL_FNAME)
+fn _get_indexer_url(kv_store: &dyn KVStoreSync) -> String {
+	kv_store.read_config(INDEXER_URL_FNAME).expect("indexer_url must be in KVStore")
 }
 
 fn _new_rgb_wallet(
@@ -179,18 +190,20 @@ fn _new_rgb_wallet(
 	.expect("valid rgb-lib wallet")
 }
 
-fn _get_wallet_data(ldk_data_dir: &Path) -> (String, BitcoinNetwork, String, String, String) {
+fn _get_wallet_data(
+	ldk_data_dir: &Path, kv_store: &dyn KVStoreSync,
+) -> (String, BitcoinNetwork, String, String, String) {
 	let data_dir = ldk_data_dir.parent().unwrap().to_string_lossy().to_string();
-	let bitcoin_network = _get_bitcoin_network(ldk_data_dir);
-	let account_xpub_vanilla = _get_account_xpub_vanilla(ldk_data_dir);
-	let account_xpub_colored = _get_account_xpub_colored(ldk_data_dir);
-	let master_fingerprint = _get_master_fingerprint(ldk_data_dir);
+	let bitcoin_network = _get_bitcoin_network(kv_store);
+	let account_xpub_vanilla = _get_account_xpub_vanilla(kv_store);
+	let account_xpub_colored = _get_account_xpub_colored(kv_store);
+	let master_fingerprint = _get_master_fingerprint(kv_store);
 	(data_dir, bitcoin_network, account_xpub_vanilla, account_xpub_colored, master_fingerprint)
 }
 
-async fn _get_rgb_wallet(ldk_data_dir: &Path) -> Wallet {
+async fn _get_rgb_wallet(ldk_data_dir: &Path, kv_store: &dyn KVStoreSync) -> Wallet {
 	let (data_dir, bitcoin_network, account_xpub_vanilla, account_xpub_colored, master_fingerprint) =
-		_get_wallet_data(ldk_data_dir);
+		_get_wallet_data(ldk_data_dir, kv_store);
 	tokio::task::spawn_blocking(move || {
 		_new_rgb_wallet(
 			data_dir,
@@ -206,11 +219,12 @@ async fn _get_rgb_wallet(ldk_data_dir: &Path) -> Wallet {
 
 async fn _accept_transfer(
 	ldk_data_dir: &Path, funding_txid: String, consignment_endpoint: RgbTransport,
+	kv_store: &dyn KVStoreSync,
 ) -> Result<(RgbTransfer, Vec<Assignment>), RgbLibError> {
 	let funding_vout = 1;
 	let (data_dir, bitcoin_network, account_xpub_vanilla, account_xpub_colored, master_fingerprint) =
-		_get_wallet_data(ldk_data_dir);
-	let indexer_url = _get_indexer_url(ldk_data_dir);
+		_get_wallet_data(ldk_data_dir, kv_store);
+	let indexer_url = _get_indexer_url(kv_store);
 	tokio::task::spawn_blocking(move || {
 		let mut wallet = _new_rgb_wallet(
 			data_dir,
@@ -229,18 +243,6 @@ async fn _accept_transfer(
 	})
 	.await
 	.unwrap()
-}
-
-/// Read TransferInfo file
-pub fn read_rgb_transfer_info(path: &Path) -> TransferInfo {
-	let serialized_info = fs::read_to_string(path).expect("able to read transfer info file");
-	serde_json::from_str(&serialized_info).expect("valid transfer info")
-}
-
-/// Write TransferInfo file
-pub fn write_rgb_transfer_info(path: &PathBuf, info: &TransferInfo) {
-	let serialized_info = serde_json::to_string(&info).expect("valid transfer info");
-	fs::write(path, serialized_info).expect("able to write transfer info file")
 }
 
 fn _counterparty_output_index(
@@ -275,12 +277,14 @@ where
 {
 	let channel_id = &channel_context.channel_id;
 	let ldk_data_dir = channel_context.ldk_data_dir.as_path();
+	let kv_store = channel_context.rgb_kv_store.as_ref();
 
 	let commitment_tx = commitment_transaction.clone().built.transaction;
 
-	let (rgb_info, _) = get_rgb_channel_info_pending(channel_id, ldk_data_dir);
+	let rgb_info = get_rgb_channel_info_pending(channel_id, kv_store);
 	let contract_id = rgb_info.contract_id;
 
+	let chan_id = channel_id.0.as_hex();
 	let mut rgb_offered_htlc = 0;
 	let mut rgb_received_htlc = 0;
 	let mut last_rgb_payment_info = None;
@@ -297,68 +301,34 @@ where
 		let inbound = htlc.offered == counterparty;
 
 		let htlc_payment_hash = htlc.payment_hash.0.as_hex().to_string();
-		let mut rgb_payment_info_path = ldk_data_dir.join(htlc_payment_hash);
-		if inbound {
-			rgb_payment_info_path.set_extension(INBOUND_EXT);
+		let htlc_proxy_id = format!("{chan_id}{htlc_payment_hash}");
+		let htlc_proxy_id_pending = format!("{htlc_proxy_id}_pending");
+		let pending_key = format!("{htlc_payment_hash}_pending");
+		let namespace =
+			if inbound { RGB_PAYMENT_INFO_INBOUND_NS } else { RGB_PAYMENT_INFO_OUTBOUND_NS };
+
+		if let Ok(data) = kv_store.read(RGB_PRIMARY_NS, namespace, &pending_key) {
+			let mut rgb_payment_info: RgbPaymentInfo =
+				bincode::deserialize(&data).expect("valid data");
+			rgb_payment_info.local_rgb_amount = rgb_info.local_rgb_amount;
+			rgb_payment_info.remote_rgb_amount = rgb_info.remote_rgb_amount;
+			let data = bincode::serialize(&rgb_payment_info).expect("valid rgb payment info");
+			kv_store
+				.write(RGB_PRIMARY_NS, namespace, &htlc_proxy_id, data.clone())
+				.expect("able to write rgb payment info");
+			kv_store
+				.write(RGB_PRIMARY_NS, namespace, &htlc_proxy_id_pending, data)
+				.expect("able to write rgb pending payment info");
+			kv_store
+				.remove(RGB_PRIMARY_NS, namespace, &pending_key, false)
+				.expect("able to remove pending payment info");
+		}
+
+		let rgb_payment_info = if let Ok(data) =
+			kv_store.read(RGB_PRIMARY_NS, namespace, &htlc_proxy_id)
+		{
+			bincode::deserialize(&data).expect("valid data")
 		} else {
-			rgb_payment_info_path.set_extension(OUTBOUND_EXT);
-		}
-		let rgb_payment_info_tmp_path =
-			get_rgb_payment_info_pending_path(&htlc.payment_hash, ldk_data_dir, inbound);
-		let channel_rgb_payment_info_path = get_rgb_channel_payment_info_path(
-			channel_id,
-			&htlc.payment_hash,
-			ldk_data_dir,
-			inbound,
-			false,
-		);
-		let channel_pending_rgb_payment_info_path = get_rgb_channel_payment_info_path(
-			channel_id,
-			&htlc.payment_hash,
-			ldk_data_dir,
-			inbound,
-			true,
-		);
-		let is_compatible_rgb_payment_info = |rgb_payment_info: &RgbPaymentInfo| {
-			rgb_payment_info.contract_id == contract_id
-				&& rgb_payment_info.amount == htlc_amount_rgb
-				&& rgb_payment_info.inbound == inbound
-		};
-
-		let mut rgb_payment_info = None;
-		let mut should_persist_channel_info = false;
-		let mut used_raw_rgb_payment_info_tmp = false;
-
-		if channel_rgb_payment_info_path.exists() {
-			let candidate = parse_rgb_payment_info(&channel_rgb_payment_info_path);
-			if is_compatible_rgb_payment_info(&candidate) {
-				rgb_payment_info = Some(candidate);
-			}
-		}
-		if rgb_payment_info.is_none() && channel_pending_rgb_payment_info_path.exists() {
-			let candidate = parse_rgb_payment_info(&channel_pending_rgb_payment_info_path);
-			if is_compatible_rgb_payment_info(&candidate) {
-				rgb_payment_info = Some(candidate);
-				should_persist_channel_info = true;
-			}
-		}
-		if rgb_payment_info.is_none() && rgb_payment_info_tmp_path.exists() {
-			let candidate = parse_rgb_payment_info(&rgb_payment_info_tmp_path);
-			if is_compatible_rgb_payment_info(&candidate) {
-				rgb_payment_info = Some(candidate);
-				should_persist_channel_info = true;
-				used_raw_rgb_payment_info_tmp = true;
-			}
-		}
-		if rgb_payment_info.is_none() && rgb_payment_info_path.exists() {
-			let candidate = parse_rgb_payment_info(&rgb_payment_info_path);
-			if is_compatible_rgb_payment_info(&candidate) {
-				rgb_payment_info = Some(candidate);
-				should_persist_channel_info = true;
-			}
-		}
-		let mut rgb_payment_info = rgb_payment_info.unwrap_or_else(|| {
-			should_persist_channel_info = true;
 			let rgb_payment_info = RgbPaymentInfo {
 				contract_id,
 				amount: htlc_amount_rgb,
@@ -367,31 +337,27 @@ where
 				swap_payment: true,
 				inbound,
 			};
-			let serialized_info =
-				serde_json::to_string(&rgb_payment_info).expect("valid rgb payment info");
-			fs::write(&rgb_payment_info_path, serialized_info)
-				.expect("able to write rgb payment info file");
+			let data = bincode::serialize(&rgb_payment_info).expect("valid rgb payment info");
+			kv_store
+				.write(RGB_PRIMARY_NS, namespace, &htlc_proxy_id, data.clone())
+				.expect("able to write rgb payment info");
+			kv_store
+				.write(RGB_PRIMARY_NS, namespace, &htlc_proxy_id_pending, data.clone())
+				.expect("able to write rgb pending payment info");
+			kv_store
+				.write(RGB_PRIMARY_NS, namespace, &htlc_payment_hash, data)
+				.expect("able to write rgb payment info");
 			rgb_payment_info
-		});
-		if should_persist_channel_info {
-			rgb_payment_info.local_rgb_amount = rgb_info.local_rgb_amount;
-			rgb_payment_info.remote_rgb_amount = rgb_info.remote_rgb_amount;
-			let serialized_info =
-				serde_json::to_string(&rgb_payment_info).expect("valid rgb payment info");
-			fs::write(&channel_rgb_payment_info_path, serialized_info.clone())
-				.expect("able to write rgb payment info file");
-			fs::write(&channel_pending_rgb_payment_info_path, serialized_info)
-				.expect("able to write rgb payment info file");
-			if used_raw_rgb_payment_info_tmp && rgb_payment_info_tmp_path.exists() {
-				fs::remove_file(&rgb_payment_info_tmp_path).expect("able to remove file");
-			}
-		}
+		};
 
-		if !channel_pending_rgb_payment_info_path.exists() {
-			let serialized_info =
-				serde_json::to_string(&rgb_payment_info).expect("valid rgb payment info");
-			fs::write(&channel_pending_rgb_payment_info_path, serialized_info)
-				.expect("able to write rgb payment info file");
+		if kv_store
+			.read(RGB_PRIMARY_NS, namespace, &htlc_proxy_id_pending)
+			.is_err()
+		{
+			let data = bincode::serialize(&rgb_payment_info).expect("valid rgb payment info");
+			kv_store
+				.write(RGB_PRIMARY_NS, namespace, &htlc_proxy_id_pending, data)
+				.expect("able to write rgb pending payment info");
 		}
 
 		if inbound {
@@ -449,7 +415,7 @@ where
 	let mut psbt = RgbLibPsbt::from_str(&psbt.to_string()).unwrap();
 	let handle = Handle::current();
 	let _ = handle.enter();
-	let wallet = futures::executor::block_on(_get_rgb_wallet(ldk_data_dir));
+	let wallet = futures::executor::block_on(_get_rgb_wallet(ldk_data_dir, kv_store));
 	let (fascia, _) = wallet.color_psbt(&mut psbt, coloring_info).unwrap();
 	let psbt = Psbt::from_str(&psbt.to_string()).unwrap();
 	let modified_tx = match psbt.extract_tx() {
@@ -463,15 +429,13 @@ where
 
 	wallet.consume_fascia(fascia.clone(), Some(WitnessOrd::Ignored)).unwrap();
 
-	// save RGB transfer data to disk
 	let rgb_amount = if counterparty {
 		vout_p2wpkh_amt + rgb_offered_htlc
 	} else {
 		vout_p2wsh_amt + rgb_received_htlc
 	};
 	let transfer_info = TransferInfo { contract_id, rgb_amount };
-	let transfer_info_path = ldk_data_dir.join(format!("{txid}_transfer_info"));
-	write_rgb_transfer_info(&transfer_info_path, &transfer_info);
+	kv_store.write_rgb_transfer_info(&txid.to_string(), &transfer_info);
 
 	Ok(())
 }
@@ -479,6 +443,7 @@ where
 /// Color HTLC transaction
 pub(crate) fn color_htlc(
 	htlc_tx: &mut Transaction, htlc: &HTLCOutputInCommitment, ldk_data_dir: &Path,
+	kv_store: &dyn KVStoreSync,
 ) -> Result<(), ChannelError> {
 	if htlc.rgb_payment.is_none_or(|(_, a)| a == 0) {
 		return Ok(());
@@ -488,8 +453,7 @@ pub(crate) fn color_htlc(
 	let consignment_htlc_outpoint = htlc_tx.input.first().unwrap().previous_output;
 	let commitment_txid = consignment_htlc_outpoint.txid.to_string();
 
-	let transfer_info_path = ldk_data_dir.join(format!("{commitment_txid}_transfer_info"));
-	let transfer_info = read_rgb_transfer_info(&transfer_info_path);
+	let transfer_info = kv_store.read_rgb_transfer_info(&commitment_txid);
 	let contract_id = transfer_info.contract_id;
 
 	let asset_coloring_info = AssetColoringInfo {
@@ -505,7 +469,7 @@ pub(crate) fn color_htlc(
 	let mut psbt = RgbLibPsbt::from_str(&psbt.to_string()).unwrap();
 	let handle = Handle::current();
 	let _ = handle.enter();
-	let wallet = futures::executor::block_on(_get_rgb_wallet(ldk_data_dir));
+	let wallet = futures::executor::block_on(_get_rgb_wallet(ldk_data_dir, kv_store));
 	let (fascia, _) = wallet.color_psbt(&mut psbt, coloring_info).unwrap();
 	let psbt = Psbt::from_str(&psbt.to_string()).unwrap();
 	let modified_tx = match psbt.extract_tx() {
@@ -517,10 +481,8 @@ pub(crate) fn color_htlc(
 
 	wallet.consume_fascia(fascia.clone(), Some(WitnessOrd::Ignored)).unwrap();
 
-	// save RGB transfer data to disk
 	let transfer_info = TransferInfo { contract_id, rgb_amount: htlc_amount_rgb };
-	let transfer_info_path = ldk_data_dir.join(format!("{txid}_transfer_info"));
-	write_rgb_transfer_info(&transfer_info_path, &transfer_info);
+	kv_store.write_rgb_transfer_info(&txid.to_string(), &transfer_info);
 
 	Ok(())
 }
@@ -528,10 +490,11 @@ pub(crate) fn color_htlc(
 /// Color closing transaction
 pub(crate) fn color_closing(
 	channel_id: &ChannelId, closing_transaction: &mut ClosingTransaction, ldk_data_dir: &Path,
+	kv_store: &dyn KVStoreSync,
 ) -> Result<(), ChannelError> {
 	let closing_tx = closing_transaction.clone().built;
 
-	let (rgb_info, _) = get_rgb_channel_info_pending(channel_id, ldk_data_dir);
+	let rgb_info = get_rgb_channel_info_pending(channel_id, kv_store);
 	let contract_id = rgb_info.contract_id;
 
 	let holder_vout_amount = rgb_info.local_rgb_amount;
@@ -568,7 +531,7 @@ pub(crate) fn color_closing(
 	let mut psbt = RgbLibPsbt::from_str(&psbt.to_string()).unwrap();
 	let handle = Handle::current();
 	let _ = handle.enter();
-	let wallet = futures::executor::block_on(_get_rgb_wallet(ldk_data_dir));
+	let wallet = futures::executor::block_on(_get_rgb_wallet(ldk_data_dir, kv_store));
 	let (fascia, _) = wallet.color_psbt(&mut psbt, coloring_info).unwrap();
 	let psbt = Psbt::from_str(&psbt.to_string()).unwrap();
 	let modified_tx = match psbt.extract_tx() {
@@ -582,113 +545,35 @@ pub(crate) fn color_closing(
 
 	wallet.consume_fascia(fascia.clone(), Some(WitnessOrd::Ignored)).unwrap();
 
-	// save RGB transfer data to disk
 	let transfer_info = TransferInfo { contract_id, rgb_amount: holder_vout_amount };
-	let transfer_info_path = ldk_data_dir.join(format!("{txid}_transfer_info"));
-	write_rgb_transfer_info(&transfer_info_path, &transfer_info);
+	kv_store.write_rgb_transfer_info(&txid.to_string(), &transfer_info);
 
 	Ok(())
 }
 
-/// Get RgbPaymentInfo file path
-pub fn get_rgb_payment_info_path(
-	payment_hash: &PaymentHash, ldk_data_dir: &Path, inbound: bool,
-) -> PathBuf {
-	let mut path = ldk_data_dir.join(payment_hash.0.as_hex().to_string());
-	path.set_extension(if inbound { INBOUND_EXT } else { OUTBOUND_EXT });
-	path
-}
-
-/// Get pending RgbPaymentInfo file path scoped only to the payment hash.
-pub fn get_rgb_payment_info_pending_path(
-	payment_hash: &PaymentHash, ldk_data_dir: &Path, inbound: bool,
-) -> PathBuf {
-	_append_pending_extension(&get_rgb_payment_info_path(payment_hash, ldk_data_dir, inbound))
-}
-
-/// Get channel-scoped RgbPaymentInfo file path for a payment attached to a concrete channel.
-pub fn get_rgb_channel_payment_info_path(
-	channel_id: &ChannelId, payment_hash: &PaymentHash, ldk_data_dir: &Path, inbound: bool,
-	pending: bool,
-) -> PathBuf {
-	let mut path =
-		ldk_data_dir.join(format!("{}{}", channel_id.0.as_hex(), payment_hash.0.as_hex()));
-	path.set_extension(if inbound { INBOUND_EXT } else { OUTBOUND_EXT });
-	if pending {
-		_append_pending_extension(&path)
-	} else {
-		path
-	}
-}
-
-/// Parse RgbPaymentInfo
-pub fn parse_rgb_payment_info(rgb_payment_info_path: &PathBuf) -> RgbPaymentInfo {
-	let serialized_info =
-		fs::read_to_string(rgb_payment_info_path).expect("valid rgb payment info");
-	serde_json::from_str(&serialized_info).expect("valid rgb info file")
-}
-
-/// Get RgbInfo file path
-pub fn get_rgb_channel_info_path(channel_id: &str, ldk_data_dir: &Path, pending: bool) -> PathBuf {
-	let mut info_file_path = ldk_data_dir.join(channel_id);
-	if pending {
-		info_file_path.set_extension("pending");
-	}
-	info_file_path
-}
-
-/// Get RgbInfo file
+/// Get RgbInfo from KVStore
 pub(crate) fn get_rgb_channel_info(
-	channel_id: &str, ldk_data_dir: &Path, pending: bool,
-) -> (RgbInfo, PathBuf) {
-	let info_file_path = get_rgb_channel_info_path(channel_id, ldk_data_dir, pending);
-	let info = parse_rgb_channel_info(&info_file_path);
-	(info, info_file_path)
+	channel_id: &str, pending: bool, kv_store: &dyn KVStoreSync,
+) -> RgbInfo {
+	kv_store.read_rgb_channel_info(channel_id, pending).expect("channel info must exist in KVStore")
 }
 
-/// Get pending RgbInfo file
-pub fn get_rgb_channel_info_pending(
-	channel_id: &ChannelId, ldk_data_dir: &Path,
-) -> (RgbInfo, PathBuf) {
-	get_rgb_channel_info(&channel_id.0.as_hex().to_string(), ldk_data_dir, true)
+/// Get pending RgbInfo from KVStore
+pub fn get_rgb_channel_info_pending(channel_id: &ChannelId, kv_store: &dyn KVStoreSync) -> RgbInfo {
+	get_rgb_channel_info(&channel_id.0.as_hex().to_string(), true, kv_store)
 }
 
-/// Get marker file path used to identify trusted virtual channels for routing policy.
-pub fn get_virtual_channel_marker_path(channel_id: &str, ldk_data_dir: &Path) -> PathBuf {
-	ldk_data_dir.join(format!("{VIRTUAL_CHANNEL_MARKER_PREFIX}{channel_id}"))
+/// Whether the channel has RGB data in KVStore
+pub fn is_channel_rgb(channel_id: &ChannelId, kv_store: &dyn KVStoreSync) -> bool {
+	let channel_id_str = channel_id.0.as_hex().to_string();
+	kv_store.read_rgb_channel_info(&channel_id_str, false).is_ok()
 }
 
-/// Parse RgbInfo
-pub fn parse_rgb_channel_info(rgb_channel_info_path: &PathBuf) -> RgbInfo {
-	let serialized_info = fs::read_to_string(rgb_channel_info_path).expect("valid rgb info file");
-	serde_json::from_str(&serialized_info).expect("valid rgb info file")
-}
-
-/// Whether the channel data for a channel exist
-pub fn is_channel_rgb(channel_id: &ChannelId, ldk_data_dir: &Path) -> bool {
-	get_rgb_channel_info_path(&channel_id.0.as_hex().to_string(), ldk_data_dir, false).exists()
-}
-
-/// Write RgbInfo file
-pub fn write_rgb_channel_info(path: &PathBuf, rgb_info: &RgbInfo) {
-	let serialized_info = serde_json::to_string(&rgb_info).expect("valid rgb info");
-	fs::write(path, serialized_info).expect("able to write")
-}
-
-fn _append_pending_extension(path: &Path) -> PathBuf {
-	let mut new_path = path.to_path_buf();
-	new_path.set_extension(format!("{}_pending", new_path.extension().unwrap().to_string_lossy()));
-	new_path
-}
-
-/// Write RGB payment info to file
+/// Write RGB payment info to database
 pub fn write_rgb_payment_info_file(
-	ldk_data_dir: &Path, payment_hash: &PaymentHash, contract_id: ContractId, amount_rgb: u64,
-	swap_payment: bool, inbound: bool,
+	payment_hash: &PaymentHash, contract_id: ContractId, amount_rgb: u64, swap_payment: bool,
+	inbound: bool, kv_store: &Arc<dyn KVStoreSync + Send + Sync>,
 ) {
-	let rgb_payment_info_path = get_rgb_payment_info_path(payment_hash, ldk_data_dir, inbound);
-	let rgb_payment_info_tmp_path =
-		get_rgb_payment_info_pending_path(payment_hash, ldk_data_dir, inbound);
 	let rgb_payment_info = RgbPaymentInfo {
 		contract_id,
 		amount: amount_rgb,
@@ -697,42 +582,42 @@ pub fn write_rgb_payment_info_file(
 		swap_payment,
 		inbound,
 	};
-	let serialized_info = serde_json::to_string(&rgb_payment_info).expect("valid rgb payment info");
-	std::fs::write(rgb_payment_info_path, serialized_info.clone())
-		.expect("able to write rgb payment info file");
-	std::fs::write(rgb_payment_info_tmp_path, serialized_info)
-		.expect("able to write rgb payment info tmp file");
+	kv_store.write_rgb_payment_info(payment_hash, &rgb_payment_info);
+	let payment_hash_hex = payment_hash.0.as_hex();
+	let pending_key = format!("{payment_hash_hex}_pending");
+	let namespace =
+		if inbound { RGB_PAYMENT_INFO_INBOUND_NS } else { RGB_PAYMENT_INFO_OUTBOUND_NS };
+	let data = bincode::serialize(&rgb_payment_info).expect("valid rgb payment info");
+	kv_store
+		.write(RGB_PRIMARY_NS, namespace, &pending_key, data)
+		.expect("able to write rgb payment info pending");
 }
 
-/// Rename RGB files from temporary to final channel ID
+/// Rename RGB channel info from temporary to final channel ID in KVStore
 pub(crate) fn rename_rgb_files(
-	channel_id: &ChannelId, temporary_channel_id: &ChannelId, ldk_data_dir: &Path,
+	channel_id: &ChannelId, temporary_channel_id: &ChannelId, kv_store: &dyn KVStoreSync,
 ) {
 	let temp_chan_id = temporary_channel_id.0.as_hex().to_string();
 	let chan_id = channel_id.0.as_hex().to_string();
 
-	fs::rename(
-		get_rgb_channel_info_path(&temp_chan_id, ldk_data_dir, false),
-		get_rgb_channel_info_path(&chan_id, ldk_data_dir, false),
-	)
-	.expect("rename ok");
-	fs::rename(
-		get_rgb_channel_info_path(&temp_chan_id, ldk_data_dir, true),
-		get_rgb_channel_info_path(&chan_id, ldk_data_dir, true),
-	)
-	.expect("rename ok");
+	let rgb_info = kv_store.read_rgb_channel_info(&temp_chan_id, false).expect("rename ok");
+	kv_store.write_rgb_channel_info(&chan_id, &rgb_info, false);
+	kv_store.remove_rgb_channel_info(&temp_chan_id, false).expect("rename ok");
 
-	let funding_consignment_tmp = ldk_data_dir.join(format!("consignment_{}", temp_chan_id));
-	if funding_consignment_tmp.exists() {
-		let funding_consignment = ldk_data_dir.join(format!("consignment_{}", chan_id));
-		fs::rename(funding_consignment_tmp, funding_consignment).expect("rename ok");
+	let rgb_info = kv_store.read_rgb_channel_info(&temp_chan_id, true).expect("rename ok");
+	kv_store.write_rgb_channel_info(&chan_id, &rgb_info, true);
+	kv_store.remove_rgb_channel_info(&temp_chan_id, true).expect("rename ok");
+
+	if let Ok(consignment_data) = kv_store.read_rgb_consignment(&temp_chan_id) {
+		kv_store.write_rgb_consignment(&chan_id, consignment_data);
+		kv_store.remove_rgb_consignment(&temp_chan_id);
 	}
 }
 
 /// Handle funding on the receiver side
 pub(crate) fn handle_funding(
 	temporary_channel_id: &ChannelId, funding_txid: String, ldk_data_dir: &Path,
-	consignment_endpoint: RgbTransport, push_asset_amount: Option<u64>,
+	consignment_endpoint: RgbTransport, push_asset_amount: Option<u64>, kv_store: &dyn KVStoreSync,
 ) -> Result<(), MsgHandleErrInternal> {
 	let handle = Handle::current();
 	let _ = handle.enter();
@@ -740,6 +625,7 @@ pub(crate) fn handle_funding(
 		ldk_data_dir,
 		funding_txid.clone(),
 		consignment_endpoint,
+		kv_store,
 	));
 	let (consignment, remote_rgb_assignments) = match accept_res {
 		Ok(res) => res,
@@ -775,11 +661,11 @@ pub(crate) fn handle_funding(
 		},
 	};
 
-	let consignment_path = ldk_data_dir.join(format!("consignment_{}", funding_txid));
-	consignment.save_file(consignment_path).expect("unable to write file");
-	let consignment_path =
-		ldk_data_dir.join(format!("consignment_{}", temporary_channel_id.0.as_hex()));
-	consignment.save_file(consignment_path).expect("unable to write file");
+	let mut consignment_buf = Vec::new();
+	consignment.save(&mut consignment_buf).expect("unable to serialize consignment");
+	kv_store.write_rgb_consignment(&funding_txid, consignment_buf.clone());
+	let temp_chan_id = temporary_channel_id.0.as_hex().to_string();
+	kv_store.write_rgb_consignment(&temp_chan_id, consignment_buf);
 
 	if remote_rgb_assignments.len() != 1 {
 		return Err(MsgHandleErrInternal::send_err_msg_no_close(
@@ -800,24 +686,19 @@ pub(crate) fn handle_funding(
 		remote_rgb_amount: channel_rgb_amount - push_amount,
 	};
 	let temporary_channel_id_str = temporary_channel_id.0.as_hex().to_string();
-	write_rgb_channel_info(
-		&get_rgb_channel_info_path(&temporary_channel_id_str, ldk_data_dir, true),
-		&rgb_info,
-	);
-	write_rgb_channel_info(
-		&get_rgb_channel_info_path(&temporary_channel_id_str, ldk_data_dir, false),
-		&rgb_info,
-	);
+
+	kv_store.write_rgb_channel_info(&temporary_channel_id_str, &rgb_info, true);
+	kv_store.write_rgb_channel_info(&temporary_channel_id_str, &rgb_info, false);
 
 	Ok(())
 }
 
-/// Update RGB channel amount
+/// Update RGB channel amount in KVStore
 pub fn update_rgb_channel_amount(
-	channel_id: &str, rgb_offered_htlc: u64, rgb_received_htlc: u64, ldk_data_dir: &Path,
-	pending: bool,
+	channel_id: &str, rgb_offered_htlc: u64, rgb_received_htlc: u64, pending: bool,
+	kv_store: &dyn KVStoreSync,
 ) {
-	let (mut rgb_info, info_file_path) = get_rgb_channel_info(channel_id, ldk_data_dir, pending);
+	let mut rgb_info = get_rgb_channel_info(channel_id, pending, kv_store);
 
 	if rgb_offered_htlc > rgb_received_htlc {
 		let spent = rgb_offered_htlc - rgb_received_htlc;
@@ -829,57 +710,153 @@ pub fn update_rgb_channel_amount(
 		rgb_info.remote_rgb_amount -= received;
 	}
 
-	write_rgb_channel_info(&info_file_path, &rgb_info)
+	kv_store.write_rgb_channel_info(channel_id, &rgb_info, pending);
 }
 
 /// Update pending RGB channel amount
 pub(crate) fn update_rgb_channel_amount_pending(
-	channel_id: &ChannelId, rgb_offered_htlc: u64, rgb_received_htlc: u64, ldk_data_dir: &Path,
+	channel_id: &ChannelId, rgb_offered_htlc: u64, rgb_received_htlc: u64,
+	kv_store: &dyn KVStoreSync,
 ) {
 	update_rgb_channel_amount(
 		&channel_id.0.as_hex().to_string(),
 		rgb_offered_htlc,
 		rgb_received_htlc,
-		ldk_data_dir,
 		true,
+		kv_store,
 	)
 }
 
-/// Whether the payment is colored
-pub(crate) fn is_payment_rgb(ldk_data_dir: &Path, payment_hash: &PaymentHash) -> bool {
-	get_rgb_payment_info_path(payment_hash, ldk_data_dir, false).exists()
-		|| get_rgb_payment_info_path(payment_hash, ldk_data_dir, true).exists()
+/// extension trait for RGB-specific KVStore operations
+pub trait RgbKvStoreExt {
+	/// read transfer info from KVStore
+	fn read_rgb_transfer_info(&self, txid: &str) -> TransferInfo;
+	/// write transfer info to KVStore
+	fn write_rgb_transfer_info(&self, txid: &str, info: &TransferInfo);
+	/// read channel info from KVStore
+	fn read_rgb_channel_info(&self, channel_id: &str, pending: bool) -> Result<RgbInfo, io::Error>;
+	/// write channel info to KVStore
+	fn write_rgb_channel_info(&self, channel_id: &str, rgb_info: &RgbInfo, pending: bool);
+	/// read payment info from KVStore
+	fn read_rgb_payment_info(
+		&self, payment_hash: &PaymentHash, inbound: bool,
+	) -> Result<RgbPaymentInfo, io::Error>;
+	/// write payment info to KVStore
+	fn write_rgb_payment_info(&self, payment_hash: &PaymentHash, info: &RgbPaymentInfo);
+	/// read consignment from KVStore
+	fn read_rgb_consignment(&self, id: &str) -> Result<Vec<u8>, io::Error>;
+	/// write consignment to KVStore
+	fn write_rgb_consignment(&self, id: &str, data: Vec<u8>);
+	/// remove channel info from KVStore
+	fn remove_rgb_channel_info(&self, channel_id: &str, pending: bool) -> Result<(), io::Error>;
+	/// remove consignment from KVStore
+	fn remove_rgb_consignment(&self, id: &str);
+	/// read a wallet config value from KVStore
+	fn read_config(&self, key: &str) -> Result<String, io::Error>;
+	/// write a wallet config value to KVStore
+	fn write_config(&self, key: &str, value: &str);
+	/// whether the payment is colored
+	fn is_payment_rgb(&self, payment_hash: &PaymentHash) -> bool;
+	/// filter first hops to only include channels with sufficient RGB assets
+	fn filter_first_hops(
+		&self, payment_hash: &PaymentHash, first_hops: &mut Vec<ChannelDetails>,
+	);
 }
 
-/// Detect the contract ID of the payment and then filter hops based on contract ID and amount
-pub(crate) fn filter_first_hops(
-	ldk_data_dir: &Path, payment_hash: &PaymentHash, first_hops: &mut Vec<ChannelDetails>,
-) -> (ContractId, u64) {
-	let rgb_payment_info_path = get_rgb_payment_info_path(payment_hash, ldk_data_dir, false);
-	let rgb_payment_info = parse_rgb_payment_info(&rgb_payment_info_path);
-	let contract_id = rgb_payment_info.contract_id;
-	let rgb_amount = rgb_payment_info.amount;
-	first_hops.retain(|h| {
-		let info_file_path = ldk_data_dir.join(h.channel_id.0.as_hex().to_string());
-		if !info_file_path.exists() {
-			return false;
-		}
-		let serialized_info = fs::read_to_string(info_file_path).expect("valid rgb info file");
-		let rgb_info: RgbInfo =
-			serde_json::from_str(&serialized_info).expect("valid rgb info file");
-		rgb_info.contract_id == contract_id && rgb_info.local_rgb_amount >= rgb_amount
-	});
-	let has_virtual_rgb_hop = first_hops.iter().any(|h| {
-		let marker =
-			get_virtual_channel_marker_path(&h.channel_id.0.as_hex().to_string(), ldk_data_dir);
-		marker.exists()
-	});
-	if has_virtual_rgb_hop {
+impl<K: KVStoreSync + ?Sized> RgbKvStoreExt for K {
+	fn read_rgb_transfer_info(&self, txid: &str) -> TransferInfo {
+		let data = self.read(RGB_PRIMARY_NS, RGB_TRANSFER_INFO_NS, txid)
+			.expect("KVStore read failed");
+		bincode::deserialize(&data).expect("valid transfer info")
+	}
+
+	fn write_rgb_transfer_info(&self, txid: &str, info: &TransferInfo) {
+		let data = bincode::serialize(info).expect("valid transfer info");
+		self.write(RGB_PRIMARY_NS, RGB_TRANSFER_INFO_NS, txid, data)
+			.expect("KVStore write failed");
+	}
+
+	fn read_rgb_channel_info(&self, channel_id: &str, pending: bool) -> Result<RgbInfo, io::Error> {
+		let namespace = if pending { RGB_CHANNEL_INFO_PENDING_NS } else { RGB_CHANNEL_INFO_NS };
+		let data = self.read(RGB_PRIMARY_NS, namespace, channel_id)?;
+		bincode::deserialize(&data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+	}
+
+	fn write_rgb_channel_info(&self, channel_id: &str, rgb_info: &RgbInfo, pending: bool) {
+		let namespace = if pending { RGB_CHANNEL_INFO_PENDING_NS } else { RGB_CHANNEL_INFO_NS };
+		let data = bincode::serialize(rgb_info).expect("valid rgb channel info");
+		self.write(RGB_PRIMARY_NS, namespace, channel_id, data)
+			.expect("KVStore write failed");
+	}
+
+	fn read_rgb_payment_info(
+		&self, payment_hash: &PaymentHash, inbound: bool,
+	) -> Result<RgbPaymentInfo, io::Error> {
+		let namespace =
+			if inbound { RGB_PAYMENT_INFO_INBOUND_NS } else { RGB_PAYMENT_INFO_OUTBOUND_NS };
+		let key = payment_hash.0.as_hex().to_string();
+		let data = self.read(RGB_PRIMARY_NS, namespace, &key)?;
+		bincode::deserialize(&data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+	}
+
+	fn write_rgb_payment_info(&self, payment_hash: &PaymentHash, info: &RgbPaymentInfo) {
+		let namespace =
+			if info.inbound { RGB_PAYMENT_INFO_INBOUND_NS } else { RGB_PAYMENT_INFO_OUTBOUND_NS };
+		let key = payment_hash.0.as_hex().to_string();
+		let data = bincode::serialize(info).expect("valid rgb payment info");
+		self.write(RGB_PRIMARY_NS, namespace, &key, data)
+			.expect("KVStore write failed");
+	}
+
+	fn read_rgb_consignment(&self, id: &str) -> Result<Vec<u8>, io::Error> {
+		self.read(RGB_PRIMARY_NS, RGB_CONSIGNMENT_NS, id)
+	}
+
+	fn write_rgb_consignment(&self, id: &str, data: Vec<u8>) {
+		self.write(RGB_PRIMARY_NS, RGB_CONSIGNMENT_NS, id, data)
+			.expect("KVStore write failed");
+	}
+
+	fn remove_rgb_channel_info(&self, channel_id: &str, pending: bool) -> Result<(), io::Error> {
+		let namespace = if pending { RGB_CHANNEL_INFO_PENDING_NS } else { RGB_CHANNEL_INFO_NS };
+		self.remove(RGB_PRIMARY_NS, namespace, channel_id, false)
+	}
+
+	fn remove_rgb_consignment(&self, id: &str) {
+		self.remove(RGB_PRIMARY_NS, RGB_CONSIGNMENT_NS, id, false)
+			.expect("KVStore remove failed");
+	}
+
+	fn read_config(&self, key: &str) -> Result<String, io::Error> {
+		let data = self.read(RGB_PRIMARY_NS, RGB_WALLET_CONFIG_NS, key)?;
+		String::from_utf8(data).map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))
+	}
+
+	fn write_config(&self, key: &str, value: &str) {
+		self.write(RGB_PRIMARY_NS, RGB_WALLET_CONFIG_NS, key, value.as_bytes().to_vec())
+			.expect("KVStore write failed");
+	}
+
+	fn is_payment_rgb(&self, payment_hash: &PaymentHash) -> bool {
+		self.read_rgb_payment_info(payment_hash, false).is_ok()
+			|| self.read_rgb_payment_info(payment_hash, true).is_ok()
+	}
+
+	fn filter_first_hops(&self, payment_hash: &PaymentHash, first_hops: &mut Vec<ChannelDetails>) {
+		let rgb_payment_info = match self.read_rgb_payment_info(payment_hash, false) {
+			Ok(info) => info,
+			Err(_) => return,
+		};
+		let contract_id = rgb_payment_info.contract_id;
+		let rgb_amount = rgb_payment_info.amount;
 		first_hops.retain(|h| {
-			let marker =
-				get_virtual_channel_marker_path(&h.channel_id.0.as_hex().to_string(), ldk_data_dir);
-			marker.exists()
+			let channel_id_str = h.channel_id.0.as_hex().to_string();
+			match self.read_rgb_channel_info(&channel_id_str, false) {
+				Ok(rgb_info) => {
+					rgb_info.contract_id == contract_id && rgb_info.local_rgb_amount >= rgb_amount
+				},
+				Err(_) => false,
+			}
 		});
 	}
-	(contract_id, rgb_amount)
 }

--- a/lightning/src/sign/mod.rs
+++ b/lightning/src/sign/mod.rs
@@ -38,6 +38,7 @@ use bitcoin::{secp256k1, Psbt, Sequence, Txid, WPubkeyHash, Witness};
 use lightning_invoice::RawBolt11Invoice;
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::chain::transaction::OutPoint;
 use crate::crypto::utils::{hkdf_extract_expand_twice, sign, sign_with_aux_rand};
@@ -62,6 +63,7 @@ use crate::rgb_utils::color_htlc;
 use crate::types::features::ChannelTypeFeatures;
 use crate::types::payment::PaymentPreimage;
 use crate::util::async_poll::AsyncResult;
+use crate::util::persist::KVStoreSync;
 use crate::util::ser::{ReadableArgs, Writeable};
 use crate::util::transaction_utils;
 
@@ -1218,6 +1220,8 @@ pub struct InMemorySigner {
 	entropy_source: RandomBytes,
 	/// The LDK data directory
 	ldk_data_dir: PathBuf,
+	/// KVStore for RGB data persistence
+	rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 }
 
 impl PartialEq for InMemorySigner {
@@ -1248,6 +1252,7 @@ impl Clone for InMemorySigner {
 			channel_keys_id: self.channel_keys_id,
 			entropy_source: RandomBytes::new(self.get_secure_random_bytes()),
 			ldk_data_dir: self.ldk_data_dir.clone(),
+			rgb_kv_store: self.rgb_kv_store.clone(),
 		}
 	}
 }
@@ -1259,6 +1264,7 @@ impl InMemorySigner {
 		payment_key_v2: SecretKey, v2_remote_key_derivation: bool,
 		delayed_payment_base_key: SecretKey, htlc_base_key: SecretKey, commitment_seed: [u8; 32],
 		channel_keys_id: [u8; 32], ldk_data_dir: PathBuf, rand_bytes_unique_start: [u8; 32],
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> InMemorySigner {
 		InMemorySigner {
 			funding_key: sealed::MaybeTweakedSecretKey::from(funding_key),
@@ -1272,6 +1278,7 @@ impl InMemorySigner {
 			channel_keys_id,
 			entropy_source: RandomBytes::new(rand_bytes_unique_start),
 			ldk_data_dir,
+			rgb_kv_store,
 		}
 	}
 
@@ -1281,6 +1288,7 @@ impl InMemorySigner {
 		payment_key_v2: SecretKey, v2_remote_key_derivation: bool,
 		delayed_payment_base_key: SecretKey, htlc_base_key: SecretKey, commitment_seed: [u8; 32],
 		channel_keys_id: [u8; 32], ldk_data_dir: PathBuf, rand_bytes_unique_start: [u8; 32],
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> InMemorySigner {
 		InMemorySigner {
 			funding_key: sealed::MaybeTweakedSecretKey::from(funding_key),
@@ -1294,6 +1302,7 @@ impl InMemorySigner {
 			channel_keys_id,
 			entropy_source: RandomBytes::new(rand_bytes_unique_start),
 			ldk_data_dir,
+			rgb_kv_store,
 		}
 	}
 
@@ -1568,7 +1577,7 @@ impl EcdsaChannelSigner for InMemorySigner {
 				&keys.revocation_key,
 			);
 			if commitment_tx.is_colored() {
-				if let Err(_e) = color_htlc(&mut htlc_tx, htlc, &self.ldk_data_dir) {
+				if let Err(_e) = color_htlc(&mut htlc_tx, htlc, &self.ldk_data_dir, self.rgb_kv_store.as_ref()) {
 					return Err(());
 				}
 			}
@@ -1993,6 +2002,7 @@ pub struct KeysManager {
 	starting_time_secs: u64,
 	starting_time_nanos: u32,
 	ldk_data_dir: PathBuf,
+	rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 }
 
 impl KeysManager {
@@ -2021,6 +2031,7 @@ impl KeysManager {
 	pub fn new(
 		seed: &[u8; 32], starting_time_secs: u64, starting_time_nanos: u32,
 		v2_remote_key_derivation: bool, ldk_data_dir: PathBuf,
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Self {
 		// Constants for key derivation path indices used in this function.
 		const NODE_SECRET_INDEX: ChildNumber = ChildNumber::Hardened { index: 0 };
@@ -2115,6 +2126,7 @@ impl KeysManager {
 					starting_time_secs,
 					starting_time_nanos,
 					ldk_data_dir,
+					rgb_kv_store,
 				};
 				let secp_seed = res.get_secure_random_bytes();
 				res.secp_ctx.seeded_randomize(&secp_seed);
@@ -2234,6 +2246,7 @@ impl KeysManager {
 			params.clone(),
 			self.ldk_data_dir.clone(),
 			prng_seed,
+			self.rgb_kv_store.clone(),
 		)
 	}
 
@@ -2651,6 +2664,7 @@ impl PhantomKeysManager {
 	pub fn new(
 		seed: &[u8; 32], starting_time_secs: u64, starting_time_nanos: u32,
 		cross_node_seed: &[u8; 32], v2_remote_key_derivation: bool, ldk_data_dir: PathBuf,
+		rgb_kv_store: Arc<dyn KVStoreSync + Send + Sync>,
 	) -> Self {
 		let inner = KeysManager::new(
 			seed,
@@ -2658,6 +2672,7 @@ impl PhantomKeysManager {
 			starting_time_nanos,
 			v2_remote_key_derivation,
 			ldk_data_dir,
+			rgb_kv_store,
 		);
 		let (inbound_key, phantom_key) = hkdf_extract_expand_twice(
 			b"LDK Inbound and Phantom Payment Key Expansion",


### PR DESCRIPTION
# Implement RGB KVStore Integration

Replaces all filesystem-based RGB data persistence in `rgb_utils` with LDK's `KVStoreSync` trait, enabling database-backed storage.

## What changed

### New: KVStore namespaces and extension trait

Added namespace constants under `rgb/`:

| Namespace | Stores |
|---|---|
| `rgb/channel_info` | RGB channel balance info |
| `rgb/channel_info_pending` | Pending channel info during commitment |
| `rgb/payment_info_inbound` | Inbound RGB payment info |
| `rgb/payment_info_outbound` | Outbound RGB payment info |
| `rgb/transfer_info` | Transfer info (contract_id + amount per txid) |
| `rgb/consignment` | Consignment binary blobs |
| `rgb/wallet_config` | Wallet config strings (xpubs, network, indexer URL) |

Added `RgbKvStoreExt` trait with typed convenience methods:
- `read/write_rgb_channel_info`, `read/write_rgb_payment_info`, `read/write_rgb_transfer_info`
- `read/write/remove_rgb_consignment`
- `read/write_config`
- `is_payment_rgb`, `filter_first_hops`

Blanket impl for all `KVStoreSync` implementors.

### Removed: filesystem helpers

Deleted all file-path-based functions:
- `get_rgb_channel_info_path`, `get_rgb_payment_info_path`, `get_rgb_payment_info_pending_path`, `get_rgb_channel_payment_info_path`
- `parse_rgb_channel_info`, `parse_rgb_payment_info`
- `read_rgb_transfer_info`, `write_rgb_transfer_info` (path-based versions)
- `get_virtual_channel_marker_path`
- `_get_file_in_parent`, `_read_file_in_parent`, `_get_rgb_wallet_dir`

### Changed: config reads from KVStore instead of files

Config reader functions (`_get_bitcoin_network`, `_get_account_xpub_*`, `_get_master_fingerprint`, `_get_indexer_url`) now take `&dyn KVStoreSync` instead of `&Path` and read via `read_config()`.

### Changed: consignment storage

`handle_funding` writes consignment blobs to KVStore via `write_rgb_consignment()` + `FileContent::save(&mut Vec)` instead of `save_file()` to disk.

### Changed: `FundedChannel` deserialization

`ReadableArgs` for `FundedChannel` now includes `Arc<dyn KVStoreSync + Send + Sync>` to pass the KVStore through channel deserialization.

### Propagated `kv_store` parameter

Functions that previously only took `ldk_data_dir: &Path` now also receive `kv_store: &dyn KVStoreSync`:
- `color_commitment`, `color_htlc`, `color_closing`
- `handle_funding`, `write_rgb_payment_info_file`
- `get_rgb_channel_info`, `get_rgb_channel_info_pending`, `is_channel_rgb`
- `_get_rgb_wallet`, `_accept_transfer`
