### PR TITLE
scope commitment-coloring records to the per-channel key

### DIFF
--- a/lightning/src/rgb_utils/mod.rs
+++ b/lightning/src/rgb_utils/mod.rs
@@ -336,25 +336,26 @@ where
 				.expect("able to remove pending payment info");
 		}
 
+		// The only authoritative per-HTLC key here is `htlc_proxy_id = chan_id || payment_hash`:
+		// it's scoped to THIS channel and therefore cannot bleed into another channel that happens
+		// to see the same payment_hash (e.g. two legs of an atomic RGB swap where each leg is
+		// colored with a different asset). Any lookup keyed only by `payment_hash` would read a
+		// record written by a sibling channel and poison this channel's commitment coloring.
 		let rgb_payment_info = if let Ok(data) =
 			kv_store.read(RGB_PRIMARY_NS, namespace, &htlc_proxy_id)
 		{
-			let mut info: RgbPaymentInfo = bincode::deserialize(&data).expect("valid data");
-			info.local_rgb_amount = rgb_info.local_rgb_amount;
-			info.remote_rgb_amount = rgb_info.remote_rgb_amount;
-			info
-		} else if let Ok(mut info) = kv_store.read_rgb_payment_info(&htlc.payment_hash, inbound) {
-			info.local_rgb_amount = rgb_info.local_rgb_amount;
-			info.remote_rgb_amount = rgb_info.remote_rgb_amount;
-			let data = bincode::serialize(&info).expect("valid rgb payment info");
-			kv_store
-				.write(RGB_PRIMARY_NS, namespace, &htlc_proxy_id, data.clone())
-				.expect("able to write rgb payment info");
-			kv_store
-				.write(RGB_PRIMARY_NS, namespace, &htlc_proxy_id_pending, data)
-				.expect("able to write rgb pending payment info");
-			info
+			// Subsequent commitment updates on this channel reuse the record persisted during
+			// the first commitment that carried this HTLC.
+			bincode::deserialize(&data).expect("valid data")
 		} else {
+			// First commitment to carry this HTLC on this channel. Synthesize the record from
+			// strictly channel-scoped inputs:
+			//   - `contract_id` and balances from `rgb_info` (this channel's asset)
+			//   - `htlc_amount_rgb` from the HTLC itself
+			//   - `inbound` from `htlc.offered` vs `counterparty`
+			// `swap_payment` is hardcoded `true` because this fallback only runs on forwarders:
+			// sender-side payments pre-write the authoritative record via
+			// `write_rgb_payment_info_file` before the first commitment is built.
 			let rgb_payment_info = RgbPaymentInfo {
 				contract_id,
 				amount: htlc_amount_rgb,

--- a/lightning/src/rgb_utils/mod.rs
+++ b/lightning/src/rgb_utils/mod.rs
@@ -336,26 +336,54 @@ where
 				.expect("able to remove pending payment info");
 		}
 
-		// The only authoritative per-HTLC key here is `htlc_proxy_id = chan_id || payment_hash`:
-		// it's scoped to THIS channel and therefore cannot bleed into another channel that happens
-		// to see the same payment_hash (e.g. two legs of an atomic RGB swap where each leg is
-		// colored with a different asset). Any lookup keyed only by `payment_hash` would read a
-		// record written by a sibling channel and poison this channel's commitment coloring.
-		let rgb_payment_info = if let Ok(data) =
-			kv_store.read(RGB_PRIMARY_NS, namespace, &htlc_proxy_id)
+		// Only accept a stored candidate if it actually describes THIS HTLC on THIS channel.
+		// Matches the pre-KVStore guard in `color_commitment`: a record whose contract_id,
+		// amount, or direction disagrees with what's being coloured right now cannot have been
+		// written for this HTLC, so treating it as authoritative would poison the commitment
+		// (e.g. two legs of an atomic RGB swap sharing a payment_hash under different assets).
+		let is_compatible = |info: &RgbPaymentInfo| {
+			info.contract_id == contract_id
+				&& info.amount == htlc_amount_rgb
+				&& info.inbound == inbound
+		};
+
+		let rgb_payment_info = if let Some(info) = kv_store
+			.read(RGB_PRIMARY_NS, namespace, &htlc_proxy_id)
+			.ok()
+			.map(|data| bincode::deserialize::<RgbPaymentInfo>(&data).expect("valid data"))
+			.filter(|info| is_compatible(info))
 		{
-			// Subsequent commitment updates on this channel reuse the record persisted during
-			// the first commitment that carried this HTLC.
-			bincode::deserialize(&data).expect("valid data")
+			// Cache hit on the per-channel record. Preserve stored balances: they were the
+			// channel's snapshot at the time this HTLC was first coloured, and the later
+			// `remote_rgb_amount - rgb_received_htlc` (and local/offered) subtraction assumes
+			// that snapshot — using current `rgb_info` values can underflow if the channel
+			// state has since moved. Matches pre-KVStore `channel_rgb_payment_info_path`
+			// behaviour, where `should_persist_channel_info` stayed false on this branch.
+			info
+		} else if let Some(mut info) = kv_store
+			.read_rgb_payment_info(&htlc.payment_hash, inbound)
+			.ok()
+			.filter(|info| is_compatible(info))
+		{
+			// Fall back to the canonical payment-hash-keyed record written by the sender/payee
+			// via `write_rgb_payment_info_file`. Lets a second channel on the same node recover
+			// the authoritative payment info once the first channel has consumed the
+			// `<payment_hash>_pending` marker. Refresh balances, then persist a per-channel
+			// copy so subsequent commitment updates hit the cached branch above.
+			info.local_rgb_amount = rgb_info.local_rgb_amount;
+			info.remote_rgb_amount = rgb_info.remote_rgb_amount;
+			let data = bincode::serialize(&info).expect("valid rgb payment info");
+			kv_store
+				.write(RGB_PRIMARY_NS, namespace, &htlc_proxy_id, data.clone())
+				.expect("able to write rgb payment info");
+			kv_store
+				.write(RGB_PRIMARY_NS, namespace, &htlc_proxy_id_pending, data)
+				.expect("able to write rgb pending payment info");
+			info
 		} else {
-			// First commitment to carry this HTLC on this channel. Synthesize the record from
-			// strictly channel-scoped inputs:
-			//   - `contract_id` and balances from `rgb_info` (this channel's asset)
-			//   - `htlc_amount_rgb` from the HTLC itself
-			//   - `inbound` from `htlc.offered` vs `counterparty`
-			// `swap_payment` is hardcoded `true` because this fallback only runs on forwarders:
-			// sender-side payments pre-write the authoritative record via
-			// `write_rgb_payment_info_file` before the first commitment is built.
+			// No compatible record available (e.g. a forwarder that never saw a
+			// sender/payee-side write). Synthesize from the channel's own RGB info plus the
+			// HTLC's amount.
 			let rgb_payment_info = RgbPaymentInfo {
 				contract_id,
 				amount: htlc_amount_rgb,


### PR DESCRIPTION
### What this PR changes

`color_commitment` is the routine that annotates every HTLC on acommitment transaction with its RGB contract id, asset amount, and the channel's asset balances. It persists that annotation so the same channel can reuse it on subsequent commitment updates without re-deriving.

Until now it kept that annotation under two different keys:

- a per-channel key, formed from `channel_id || payment_hash`, and
- a payment-level key, formed from `payment_hash` alone.

Both were consulted; on a cache miss, the per-channel key was populated from the payment-level key or synthesized from scratch.

This PR drops the payment-level key from `color_commitment` entirely. `color_commitment` now only ever reads and writes the per-channel key. The synthesis fallback is unchanged in behavior; only the cross-key fallback is gone.

### Why it had to change

The payment-level key is not safe when the **same payment hash** is live on **two different channels** of the same node, and the two channels carry **different RGB assets**. This is exactly the shape of an atomic RGB swap: both legs of the swap share one hash, and a node that sits on both legs holds two HTLCs coloured with two different contract ids.

In that configuration both channels' coloring runs touched the payment-level key:

- Channel 1's run writes contract id A under the hash.
- Channel 2's run reads the same key, finds A, and uses it to colour its HTLC — which really carries contract id B.

Channel 2 is now producing a commitment whose asset annotation disagrees with the counterparty's. Commitment signatures no longer match the other side's view of the transaction, the peer rejects the commitment as invalid, and the channel force-closes.

The per-channel key does not have this problem: different channels never share it.
