### PR TITLE
skip OP_RETURN outputs when resolving tx confirmation height

### DIFF
--- a/lightning-transaction-sync/src/electrum.rs
+++ b/lightning-transaction-sync/src/electrum.rs
@@ -290,11 +290,21 @@ where
 					}
 
 					watched_txs.push((txid, tx.clone()));
-					if let Some(tx_out) = tx.output.first() {
-						// We watch an arbitrary output of the transaction of interest in order to
-						// retrieve the associated script history, before narrowing down our search
-						// through `filter`ing by `txid` below.
-						watched_script_pubkeys.push(tx_out.script_pubkey.clone());
+					// We watch an output of the transaction of interest in order to retrieve the
+					// associated script history, before narrowing down our search through
+					// `filter`ing by `txid` below. We skip OP_RETURN outputs as Electrum servers
+					// don't index provably-unspendable scripts (e.g. the RGB commitment at vout 0
+					// of a colored funding tx), so their history is empty and the tx would never
+					// be seen as confirmed. We fall back to the first output to keep this lookup
+					// aligned with `watched_txs`.
+					let script_pubkey = tx
+						.output
+						.iter()
+						.find(|o| !o.script_pubkey.is_op_return())
+						.or_else(|| tx.output.first())
+						.map(|o| o.script_pubkey.clone());
+					if let Some(script_pubkey) = script_pubkey {
+						watched_script_pubkeys.push(script_pubkey);
 					} else {
 						debug_assert!(false, "Failed due to retrieving invalid tx data.");
 						log_error!(self.logger, "Failed due to retrieving invalid tx data.");


### PR DESCRIPTION
### Issue

When a node runs with an Electrum indexer only (no bitcoind RPC), RGB-asset Lightning channels never become usable. The funding transaction confirms on-chain, but the node keeps reporting zero confirmations for it, so the channel never reaches channel_ready. This happens because RGB colored funding transactions put an OP_RETURN (the RGB commitment) as their first output. The Electrum sync client looks up a transaction's confirmation by querying the script history of its first output, and Electrum servers don't index OP_RETURN scripts, so the lookup comes back empty and the funding is never seen as confirmed. Plain BTC channels work because their first output is a normal, indexed script, and bitcoind/esplora modes work because they don't rely on this script-history lookup.

### FIX

When resolving a transaction's confirmation height, pick the first non-OP_RETURN output to query script history instead of blindly using the first output, falling back to the first output if none qualifies. A funding transaction always has a normal (indexed) output, so its history is found and the confirmation is detected correctly. The change is limited to the Electrum sync path and doesn't affect normal transactions, whose first output is already a normal script.
