### PR TITLE
Serialize rgb_payment for pending inbound and outbound HTLCs

### DIFF
--- a/lightning/src/ln/channel.rs
+++ b/lightning/src/ln/channel.rs
@@ -14851,6 +14851,7 @@ where
 					}
 				},
 			}
+			htlc.rgb_payment.write(writer)?;
 		}
 
 		// The elements of this vector will always be `Some` starting in 0.2,
@@ -14900,6 +14901,7 @@ where
 					reason.write(writer)?;
 				},
 			}
+			htlc.rgb_payment.write(writer)?;
 			pending_outbound_skimmed_fees.push(htlc.skimmed_fee_msat);
 			pending_outbound_blinding_points.push(htlc.blinding_point);
 			pending_outbound_held_htlc_flags.push(htlc.hold_htlc);


### PR DESCRIPTION
A channel writes the `rgb_payment` field only for holding-cell HTLCs, but reads it back for pending inbound and outbound HTLCs too. The read and write sides disagree, so the fix simply writes `rgb_payment` for those HTLCs as well — making the two sides symmetric. The read path is unchanged.

If a channel is saved while it still has a pending inbound or outbound HTLC, the extra read with no matching write makes the deserializer read past the field, drift, and fail with `DecodeError::InvalidValue`. In practice that means the whole `ChannelManager` can't be loaded and the node won't restart. It stays hidden as long as HTLCs settle before the channel is saved, and shows up as soon as one is still in flight at save time.

## Test

Reproduced end-to-end in rgb-lightning-node by [`restart_with_pending_rgb_htlc_recovers_channel`](https://github.com/dcorral/rgb-lightning-node/blob/29da33b0693ebf48ad04e2794c8980850c3d2211/src/test/rgb_payment_htlc_persistence.rs#L14). It pays a hodl invoice to hold an RGB HTLC open, restarts both nodes, and checks the channel comes back and the payment can be settled. The test fails (`InvalidValue` on restart) without this fix and passes with it.
