### PR TITLE
Bump rgb-lib to v0.3.0-beta.27

### DIFF
--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
 
 # RGB and related
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.26", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.27", features = [
     "electrum",
     "esplora",
 ] }

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -54,7 +54,7 @@ inventory = { version = "0.3", optional = true  }
 # RGB and related
 bincode = "1.3"
 futures = "0.3"
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.26", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.27", features = [
     "electrum",
     "esplora",
 ] }


### PR DESCRIPTION
Points the rgb-lib dependency (in lightning and lightning-invoice) at the branch that adds list_transfers_by_txid, so downstream consumers can resolve RGB transfers by on-chain txid. Same kind of change as #22 ("Bump rgb-lib to v0.3.0-beta.26"), just targeting the feature branch for now.

This is temporary: once the rgb-lib change merges and a release is tagged, this should be re-pointed from the branch to that tag.