### PR TITLE
chore: add bump-rgb-lib workflow and workflow_dispatch to CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches-ignore:
       - master
+  workflow_dispatch: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/bump-rgb-lib.yml
+++ b/.github/workflows/bump-rgb-lib.yml
@@ -1,0 +1,68 @@
+name: Bump rgb-lib version
+
+on:
+  repository_dispatch:
+    types: [rgb-lib-release]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'rgb-lib tag (e.g. v0.3.0-beta.28)'
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            RAW="${{ github.event.client_payload.version }}"
+          else
+            RAW="${{ inputs.version }}"
+          fi
+          VERSION="${RAW#v}"
+          VERSION="v${VERSION}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "branch=bump/rgb-lib-$VERSION" >> $GITHUB_OUTPUT
+
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+
+      - name: Update rgb-lib tag in Cargo.toml files
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i "s|tag = \"v[^\"]*\"|tag = \"${VERSION}\"|g" lightning/Cargo.toml
+          sed -i "s|tag = \"v[^\"]*\"|tag = \"${VERSION}\"|g" lightning-invoice/Cargo.toml
+
+      - name: Commit and push bump branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "${{ steps.version.outputs.branch }}"
+          git add lightning/Cargo.toml lightning-invoice/Cargo.toml
+          git diff --cached --quiet && echo "No changes, exiting" && exit 0
+          git commit -m "chore: bump rgb-lib to ${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.branch }}"
+
+      - name: Create pull request
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr create \
+            --title "chore: bump rgb-lib to ${{ steps.version.outputs.version }}" \
+            --body "Automated bump of rgb-lib to [${{ steps.version.outputs.version }}](https://github.com/UTEXO-Protocol/rgb-lib/releases/tag/${{ steps.version.outputs.version }})." \
+            --base dev \
+            --head "${{ steps.version.outputs.branch }}"
+
+      - name: Dispatch CI on bump branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build.yml --ref "${{ steps.version.outputs.branch }}"


### PR DESCRIPTION
Adds automation to bump the `rgb-lib` dependency when a new release is published.

## What changes
- **`bump-rgb-lib.yml`** — new workflow triggered by `repository_dispatch` (from rgb-lib's `release.yml`) or manually via `workflow_dispatch`. Updates the `tag` in `lightning/Cargo.toml` and `lightning-invoice/Cargo.toml`, creates a PR to `dev`, then explicitly dispatches CI on the bump branch.
- **`build.yml`** — adds `workflow_dispatch: {}` so CI can be triggered on arbitrary branches (used by the bump workflow above).