### PR TITLE
fix: use PAT for PR creation in bump-rgb-lib workflow

### DIFF
--- a/.github/workflows/bump-rgb-lib.yml
+++ b/.github/workflows/bump-rgb-lib.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Create pull request
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RGB_LIB_RUST_LIGHTNING_PAT }}
         run: |
           gh pr create \
             --title "chore: bump rgb-lib to ${{ steps.version.outputs.version }}" \
@@ -63,6 +63,6 @@ jobs:
 
       - name: Dispatch CI on bump branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RGB_LIB_RUST_LIGHTNING_PAT }}
         run: |
           gh workflow run build.yml --ref "${{ steps.version.outputs.branch }}"


### PR DESCRIPTION
## Summary
- Replace `secrets.GITHUB_TOKEN` with `secrets.RGB_LIB_RUST_LIGHTNING_PAT` in both `Create pull request` and `Dispatch CI on bump branch` steps
- `GITHUB_TOKEN` fails with `GitHub Actions is not permitted to create or approve pull requests` due to org-level restriction

## Test plan
- [ ] Trigger `bump-rgb-lib` workflow via `workflow_dispatch` with a test version after merging
- [ ] Verify PR is created successfully on `dev` branch