### PR TITLE
chore: bump rgb-lib to v0.3.0-beta.31

### DIFF
--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
 
 # RGB and related
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.27", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.31", features = [
     "electrum",
     "esplora",
 ] }

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -54,7 +54,7 @@ inventory = { version = "0.3", optional = true  }
 # RGB and related
 bincode = "1.3"
 futures = "0.3"
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.27", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.31", features = [
     "electrum",
     "esplora",
 ] }


### PR DESCRIPTION
Automated bump of rgb-lib to [v0.3.0-beta.31](https://github.com/UTEXO-Protocol/rgb-lib/releases/tag/v0.3.0-beta.31).