### PR TITLE
Pin rgb-lib contract import revision

### DIFF
--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
 
 # RGB and related
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.32", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "d7d9b230cb5c1d989b2cdd92eed966290d9ac00f", features = [
     "electrum",
     "esplora",
 ] }

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
 
 # RGB and related
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "d7d9b230cb5c1d989b2cdd92eed966290d9ac00f", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "b33aac2188c386a2addc8feb1a99663033c32c07", features = [
     "electrum",
     "esplora",
 ] }

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
 
 # RGB and related
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "b33aac2188c386a2addc8feb1a99663033c32c07", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "95332c41fd715939ac6e078ad859d474b1f6fa9b", features = [
     "electrum",
     "esplora",
 ] }

--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
 
 # RGB and related
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "95332c41fd715939ac6e078ad859d474b1f6fa9b", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "79c0a97d20f9eac0b5d346f4e3c7d2715e424bc3", features = [
     "electrum",
     "esplora",
 ] }

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -56,7 +56,7 @@ amplify = "4.8"
 bincode = "1.3"
 rgb-strict-encoding = "1.0.1"
 futures = "0.3"
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.32", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "d7d9b230cb5c1d989b2cdd92eed966290d9ac00f", features = [
     "electrum",
     "esplora",
 ] }

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -56,7 +56,7 @@ amplify = "4.8"
 bincode = "1.3"
 rgb-strict-encoding = "1.0.1"
 futures = "0.3"
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "b33aac2188c386a2addc8feb1a99663033c32c07", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "95332c41fd715939ac6e078ad859d474b1f6fa9b", features = [
     "electrum",
     "esplora",
 ] }

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -56,7 +56,7 @@ amplify = "4.8"
 bincode = "1.3"
 rgb-strict-encoding = "1.0.1"
 futures = "0.3"
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "95332c41fd715939ac6e078ad859d474b1f6fa9b", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "79c0a97d20f9eac0b5d346f4e3c7d2715e424bc3", features = [
     "electrum",
     "esplora",
 ] }

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -56,7 +56,7 @@ amplify = "4.8"
 bincode = "1.3"
 rgb-strict-encoding = "1.0.1"
 futures = "0.3"
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "d7d9b230cb5c1d989b2cdd92eed966290d9ac00f", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", rev = "b33aac2188c386a2addc8feb1a99663033c32c07", features = [
     "electrum",
     "esplora",
 ] }


### PR DESCRIPTION
## Purpose

Make the contract-only RGB import API merged in [UTEXO-Protocol/rgb-lib#68](https://github.com/UTEXO-Protocol/rgb-lib/pull/68) available to RGB Lightning Node without introducing a second rgb-lib revision into the Lightning dependency graph.

## Changes

- pin `lightning` to the immutable rgb-lib merge commit `79c0a97d20f9eac0b5d346f4e3c7d2715e424bc3`
- pin `lightning-invoice` to the same exact revision
- no Lightning protocol, channel-funding, or runtime behavior changes

Keeping both crates on one immutable rgb-lib revision prevents duplicate RGB types and makes the downstream build reproducible.

## Why this is still needed

Current rust-lightning `dev` uses rgb-lib tag `v0.3.0-beta.32`, which predates the contract-only import API. Until a later official rgb-lib release containing #68 is adopted, this pin is the bridge required by [UTEXO-Protocol/rgb-lightning-node#128](https://github.com/UTEXO-Protocol/rgb-lightning-node/pull/128).

This PR is independent of the RGB funding-recovery stack in rust-lightning #32 and rgb-lightning-node #139/#140. It does not block or modify their recovery semantics.

## Validation

Validated at `de7dd6625`:

- `cargo check -p lightning -p lightning-invoice`
- the resolved build uses rgb-lib commit `79c0a97d`

## Merge order

1. rgb-lib #68 is merged.
2. Merge this PR.
3. Advance the rust-lightning submodule in rgb-lightning-node #128 to the resulting rust-lightning `dev` commit.
