### PR TITLE
Treat monitor-held spontaneous payments as in flight

### DIFF
--- a/lightning/src/ln/outbound_payment.rs
+++ b/lightning/src/ln/outbound_payment.rs
@@ -947,8 +947,29 @@ impl OutboundPayments {
 			payment_id, None, &onion_session_privs, false, node_signer, best_block_height,
 			&send_payment_along_path
 		);
-		log_info!(logger, "Sending spontaneous payment with id {} and hash {} returned {:?}",
-			payment_id, payment_hash, res);
+		match &res {
+			Ok(()) => {
+				log_info!(logger,
+					"Sending spontaneous payment with id {} and hash {} succeeded",
+					payment_id, payment_hash);
+			},
+			Err(PaymentSendFailure::PartialFailure { .. }) => {
+				log_info!(logger,
+					"Sending spontaneous payment with id {} and hash {} is awaiting durable channel state",
+					payment_id, payment_hash);
+			},
+			Err(error) => {
+				log_error!(logger,
+					"Sending spontaneous payment with id {} and hash {} failed: {:?}",
+					payment_id, payment_hash, error);
+			},
+		}
+		if matches!(res, Err(PaymentSendFailure::PartialFailure { .. })) {
+			// At least one path was accepted by the channel state machine. In particular,
+			// MonitorUpdateInProgress means the HTLC is held until its monitor update is durable.
+			// Reporting a retryable error could make the caller submit the payment twice.
+			return Ok(());
+		}
 		if let Err(ref e) = res {
 			self.remove_outbound_if_all_failed(payment_id, e);
 			if let PaymentSendFailure::AllFailedResendSafe(_) = e {
@@ -2961,6 +2982,62 @@ mod tests {
 			((1 << 16) + 3, vec![42; 32]),
 		];
 		assert!(onion_fields.with_custom_tlvs(good_tlvs).is_ok());
+	}
+
+	#[test]
+	#[rustfmt::skip]
+	fn spontaneous_route_accepts_monitor_update_in_progress_as_in_flight() {
+		let logger = test_utils::TestLogger::new();
+		let logger_ref = &logger;
+		let log = WithContext::from(&logger_ref, None, None, Some(PaymentHash([1; 32])));
+		let outbound_payments = OutboundPayments::new(
+			new_hash_map(),
+			Arc::new(test_utils::TestStore::new(false)),
+		);
+		let keys_manager = test_utils::TestKeysInterface::new(&[2; 32], Network::Testnet);
+		let secp_ctx = Secp256k1::new();
+		let receiver_pk = PublicKey::from_secret_key(
+			&secp_ctx, &SecretKey::from_slice(&[3; 32]).unwrap(),
+		);
+		let payment_preimage = PaymentPreimage([4; 32]);
+		let payment_hash = payment_preimage.into();
+		let payment_id = PaymentId([5; 32]);
+		let route = Route {
+			paths: vec![Path {
+				hops: vec![RouteHop {
+					payment_amount: 1_000,
+					rgb_payment: None,
+					pubkey: receiver_pk,
+					node_features: NodeFeatures::empty(),
+					short_channel_id: 42,
+					channel_features: ChannelFeatures::empty(),
+					fee_msat: 1_000,
+					cltv_expiry_delta: 18,
+					maybe_announced_channel: false,
+				}],
+				blinded_tail: None,
+			}],
+			route_params: None,
+		};
+		let pending_events = Mutex::new(VecDeque::new());
+
+		let result = outbound_payments.send_spontaneous_payment_with_route(
+			route,
+			payment_hash,
+			payment_preimage,
+			RecipientOnionFields::spontaneous_empty(),
+			payment_id,
+			&&keys_manager,
+			&&keys_manager,
+			0,
+			&pending_events,
+			|_| Err(APIError::MonitorUpdateInProgress),
+			&log,
+		);
+
+		assert!(result.is_ok());
+		assert!(pending_events.lock().unwrap().is_empty());
+		assert!(outbound_payments.pending_outbound_payments.lock().unwrap().contains_key(&payment_id));
 	}
 
 	#[test]


### PR DESCRIPTION
## Summary

Treat a spontaneous payment with a partially accepted route as in flight instead of reporting a resend-safe failure.

## Root cause

`pay_route_internal()` returns `PaymentSendFailure::PartialFailure` when at least one path has entered the channel state machine but cannot be released yet, including `APIError::MonitorUpdateInProgress`. The existing wrapper converted every error into `RetryableSendFailure::RouteNotFound`, emitted `PaymentFailed`, and allowed callers to retry while the original HTLC was still pending.

That behavior can duplicate a payment attempt across a monitor-persistence boundary.

## Change

- Return success for `PartialFailure`, preserving the pending outbound payment.
- Do not emit `PaymentFailed` for an in-flight partial result.
- Keep true all-path failures on the existing failure path.
- Log success, durable-state wait, and failure as distinct outcomes.
- Add a focused regression test for `MonitorUpdateInProgress`.

## Validation

- `cargo check -p lightning --lib --features _rln_test_hooks` passes on current `dev`.
- The focused regression passes as part of the restored **1,188-test** suite in #32.

Current `dev` cannot compile its unit-test target independently because the UTEXO fork has pre-existing disabled test utilities/macros. The attempted focused invocation fails in unrelated test modules before this test can run. #32 restores that test harness; this limitation is stated here rather than hidden.

## Relationship to #32

#32 already contains this safety fix because it was discovered while exercising delayed monitor persistence. This narrow PR exists so the payment semantic can be reviewed independently. If accepted first, #32 should be rebased to drop the duplicate hunk.
