### PR TITLE
chore: bump rgb-lib to v0.3.0-beta.34

### DIFF
--- a/lightning-invoice/Cargo.toml
+++ b/lightning-invoice/Cargo.toml
@@ -24,7 +24,7 @@ serde = { version = "1.0", optional = true, default-features = false, features =
 bitcoin = { version = "0.32.2", default-features = false, features = ["secp-recovery"] }
 
 # RGB and related
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.32", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.34", features = [
     "electrum",
     "esplora",
 ] }

--- a/lightning/Cargo.toml
+++ b/lightning/Cargo.toml
@@ -56,7 +56,7 @@ amplify = "4.8"
 bincode = "1.3"
 rgb-strict-encoding = "1.0.1"
 futures = "0.3"
-rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.32", features = [
+rgb-lib = { git = "https://github.com/UTEXO-Protocol/rgb-lib.git", tag = "v0.3.0-beta.34", features = [
     "electrum",
     "esplora",
 ] }


### PR DESCRIPTION
Automated bump of rgb-lib to [v0.3.0-beta.34](https://github.com/UTEXO-Protocol/rgb-lib/releases/tag/v0.3.0-beta.34).